### PR TITLE
refactor Networking implementation

### DIFF
--- a/libraries/networking/README.md
+++ b/libraries/networking/README.md
@@ -7,7 +7,9 @@ The Networking API provides a framework for client-server communication.
 The API provides a several events to track the lifecycle of a client-server connection.
 `ClientConnectionEvents` has events for the client side, whereas `ServerConnectionEvents`
 has events for the server side. The `LOGIN` event is fired after a successful login occurs,
-and the `DISCONNECT` event is fired when a player disconnects from the server.
+the `PLAY_READY` event is fired once channel registration is complete and data can safely
+be sent over the connection, and the `DISCONNECT` event is fired when a player disconnects
+from the server.
 
 In 1.3 and above, singleplayer worlds are run on an integrated server, and these events
 are also fired for connections to integrated servers.

--- a/libraries/networking/networking-mc1.13-pre4-mc18w30b/src/main/java/net/ornithemc/osl/networking/api/client/ClientConnectionEvents.java
+++ b/libraries/networking/networking-mc1.13-pre4-mc18w30b/src/main/java/net/ornithemc/osl/networking/api/client/ClientConnectionEvents.java
@@ -10,10 +10,19 @@ public class ClientConnectionEvents {
 
 	/**
 	 * This event is fired after a successful login occurs.
+	 * Note that channel registration happens after login,
+	 * and until then data cannot safely be sent to the server.
 	 * This applies to connections to dedicated servers as
 	 * well as connections to integrated servers.
 	 */
 	public static final Event<Consumer<Minecraft>> LOGIN = Event.consumer();
+	/**
+	 * This event is fired after login, once channel registration is complete.
+	 * This marks the moment data can safely be sent to the server.
+	 * This applies to connections to dedicated servers as
+	 * well as connections to integrated servers.
+	 */
+	public static final Event<Consumer<Minecraft>> PLAY_READY = Event.consumer();
 	/**
 	 * This event is fired when the client disconnects from the server.
 	 * This applies to connections to dedicated servers as

--- a/libraries/networking/networking-mc1.13-pre4-mc18w30b/src/main/java/net/ornithemc/osl/networking/api/client/ClientPlayNetworking.java
+++ b/libraries/networking/networking-mc1.13-pre4-mc18w30b/src/main/java/net/ornithemc/osl/networking/api/client/ClientPlayNetworking.java
@@ -35,6 +35,13 @@ public final class ClientPlayNetworking {
 	}
 
 	/**
+	 * Check whether the connection is ready for data to be sent to the server.
+	 */
+	public static boolean isPlayReady() {
+		return ClientPlayNetworkingImpl.isPlayReady();
+	}
+
+	/**
 	 * Check whether the given channel is open for data to be sent through it.
 	 * This method will return {@code false} if the client is not connected to a
 	 * server, or if the server has no listeners for the given channel.

--- a/libraries/networking/networking-mc1.13-pre4-mc18w30b/src/main/java/net/ornithemc/osl/networking/api/server/ServerConnectionEvents.java
+++ b/libraries/networking/networking-mc1.13-pre4-mc18w30b/src/main/java/net/ornithemc/osl/networking/api/server/ServerConnectionEvents.java
@@ -11,10 +11,19 @@ public class ServerConnectionEvents {
 
 	/**
 	 * This event is fired after a successful login occurs.
+	 * Note that channel registration happens after login,
+	 * and until then data cannot safely be sent to the client.
 	 * This applies to connections to dedicated servers as
 	 * well as connections to integrated servers.
 	 */
 	public static final Event<BiConsumer<MinecraftServer, ServerPlayerEntity>> LOGIN = Event.biConsumer();
+	/**
+	 * This event is fired after login, once channel registration is complete.
+	 * This marks the moment data can safely be sent to the client.
+	 * This applies to connections to dedicated servers as
+	 * well as connections to integrated servers.
+	 */
+	public static final Event<BiConsumer<MinecraftServer, ServerPlayerEntity>> PLAY_READY = Event.biConsumer();
 	/**
 	 * This event is fired when a client disconnects from the server.
 	 * This applies to connections to dedicated servers as

--- a/libraries/networking/networking-mc1.13-pre4-mc18w30b/src/main/java/net/ornithemc/osl/networking/api/server/ServerPlayNetworking.java
+++ b/libraries/networking/networking-mc1.13-pre4-mc18w30b/src/main/java/net/ornithemc/osl/networking/api/server/ServerPlayNetworking.java
@@ -36,6 +36,13 @@ public final class ServerPlayNetworking {
 	}
 
 	/**
+	 * Check whether the connection is ready for data to be sent to the client.
+	 */
+	public static boolean isPlayReady(ServerPlayerEntity player) {
+		return ServerPlayNetworkingImpl.isPlayReady(player);
+	}
+
+	/**
 	 * Check whether the given channel is open for data to be sent through it.
 	 * This method will return {@code false} if the client has no listeners for
 	 * the given channel.

--- a/libraries/networking/networking-mc1.13-pre4-mc18w30b/src/main/java/net/ornithemc/osl/networking/impl/Networking.java
+++ b/libraries/networking/networking-mc1.13-pre4-mc18w30b/src/main/java/net/ornithemc/osl/networking/impl/Networking.java
@@ -4,19 +4,22 @@ import java.util.LinkedHashSet;
 import java.util.Set;
 
 import net.minecraft.network.PacketByteBuf;
+import net.minecraft.resource.Identifier;
 
 import net.ornithemc.osl.entrypoints.api.ModInitializer;
 import net.ornithemc.osl.entrypoints.api.client.ClientModInitializer;
 import net.ornithemc.osl.lifecycle.api.client.MinecraftClientEvents;
 import net.ornithemc.osl.lifecycle.api.server.MinecraftServerEvents;
+import net.ornithemc.osl.networking.api.client.ClientConnectionEvents;
 import net.ornithemc.osl.networking.api.client.ClientPlayNetworking;
+import net.ornithemc.osl.networking.api.server.ServerConnectionEvents;
 import net.ornithemc.osl.networking.api.server.ServerPlayNetworking;
 import net.ornithemc.osl.networking.impl.client.ClientPlayNetworkingImpl;
 import net.ornithemc.osl.networking.impl.interfaces.mixin.IClientPlayNetworkHandler;
 import net.ornithemc.osl.networking.impl.interfaces.mixin.IServerPlayNetworkHandler;
 import net.ornithemc.osl.networking.impl.server.ServerPlayNetworkingImpl;
 
-public class NetworkingInitializer implements ModInitializer, ClientModInitializer {
+public class Networking implements ModInitializer, ClientModInitializer {
 
 	@Override
 	public void init() {
@@ -27,11 +30,8 @@ public class NetworkingInitializer implements ModInitializer, ClientModInitializ
 			ServerPlayNetworkingImpl.destroy(server);
 		});
 		ServerPlayNetworking.registerListener(CommonChannels.CHANNELS, (server, handler, player, data) -> {
-			Set<String> channels = readChannels(data);
-
-			if (!channels.isEmpty()) {
-				((IServerPlayNetworkHandler)handler).osl$networking$registerClientChannels(channels);
-			}
+			((IServerPlayNetworkHandler)handler).osl$networking$registerClientChannels(readChannels(data));
+			ServerConnectionEvents.PLAY_READY.invoker().accept(server, player);
 
 			return true;
 		});
@@ -46,34 +46,31 @@ public class NetworkingInitializer implements ModInitializer, ClientModInitializ
 			ClientPlayNetworkingImpl.destroy(minecraft);
 		});
 		ClientPlayNetworking.registerListener(CommonChannels.CHANNELS, (minecraft, handler, data) -> {
-			Set<String> channels = readChannels(data);
-
-			if (!channels.isEmpty()) {
-				((IClientPlayNetworkHandler)handler).osl$networking$registerServerChannels(channels);
-			}
+			((IClientPlayNetworkHandler)handler).osl$networking$registerServerChannels(readChannels(data));
+			ClientConnectionEvents.PLAY_READY.invoker().accept(minecraft);
 
 			return true;
 		});
 	}
 
-	public static Set<String> readChannels(PacketByteBuf data) {
-		Set<String> channels = new LinkedHashSet<>();
+	public static Set<Identifier> readChannels(PacketByteBuf data) {
+		Set<Identifier> channels = new LinkedHashSet<>();
 		int channelCount = data.readInt();
 
 		if (channelCount > 0) {
 			for (int i = 0; i < channelCount; i++) {
-				channels.add(data.readString(20));
+				channels.add(data.readIdentifier());
 			}
 		}
 
 		return channels;
 	}
 
-	public static void writeChannels(PacketByteBuf data, Set<String> channels) {
+	public static void writeChannels(PacketByteBuf data, Set<Identifier> channels) {
 		data.writeInt(channels.size());
 
-		for (String channel : channels) {
-			data.writeString(channel);
+		for (Identifier channel : channels) {
+			data.writeIdentifier(channel);
 		}
 	}
 }

--- a/libraries/networking/networking-mc1.13-pre4-mc18w30b/src/main/java/net/ornithemc/osl/networking/impl/Networking.java
+++ b/libraries/networking/networking-mc1.13-pre4-mc18w30b/src/main/java/net/ornithemc/osl/networking/impl/Networking.java
@@ -30,6 +30,11 @@ public class Networking implements ModInitializer, ClientModInitializer {
 			ServerPlayNetworkingImpl.destroy(server);
 		});
 		ServerPlayNetworking.registerListener(CommonChannels.CHANNELS, (server, handler, player, data) -> {
+			// send channel registration data as a response to receiving client channel registration data
+			ServerPlayNetworkingImpl.doSend(player, CommonChannels.CHANNELS, response -> {
+				Networking.writeChannels(response, ServerPlayNetworkingImpl.LISTENERS.keySet());
+			});
+
 			((IServerPlayNetworkHandler)handler).osl$networking$registerClientChannels(readChannels(data));
 			ServerConnectionEvents.PLAY_READY.invoker().accept(server, player);
 

--- a/libraries/networking/networking-mc1.13-pre4-mc18w30b/src/main/java/net/ornithemc/osl/networking/impl/client/ClientPlayNetworkingImpl.java
+++ b/libraries/networking/networking-mc1.13-pre4-mc18w30b/src/main/java/net/ornithemc/osl/networking/impl/client/ClientPlayNetworkingImpl.java
@@ -77,6 +77,11 @@ public final class ClientPlayNetworkingImpl {
 		return false;
 	}
 
+	public static boolean isPlayReady() {
+		IClientPlayNetworkHandler handler = (IClientPlayNetworkHandler)minecraft.getNetworkHandler();
+		return handler != null && handler.osl$networking$isPlayReady();
+	}
+
 	public static boolean canSend(Identifier channel) {
 		IClientPlayNetworkHandler handler = (IClientPlayNetworkHandler)minecraft.getNetworkHandler();
 		return handler != null && handler.osl$networking$isRegisteredServerChannel(channel);

--- a/libraries/networking/networking-mc1.13-pre4-mc18w30b/src/main/java/net/ornithemc/osl/networking/impl/interfaces/mixin/IClientPlayNetworkHandler.java
+++ b/libraries/networking/networking-mc1.13-pre4-mc18w30b/src/main/java/net/ornithemc/osl/networking/impl/interfaces/mixin/IClientPlayNetworkHandler.java
@@ -6,6 +6,8 @@ import net.minecraft.resource.Identifier;
 
 public interface IClientPlayNetworkHandler {
 
+	boolean osl$networking$isPlayReady();
+
 	void osl$networking$registerServerChannels(Set<Identifier> channels);
 
 	boolean osl$networking$isRegisteredServerChannel(Identifier channel);

--- a/libraries/networking/networking-mc1.13-pre4-mc18w30b/src/main/java/net/ornithemc/osl/networking/impl/interfaces/mixin/IServerPlayNetworkHandler.java
+++ b/libraries/networking/networking-mc1.13-pre4-mc18w30b/src/main/java/net/ornithemc/osl/networking/impl/interfaces/mixin/IServerPlayNetworkHandler.java
@@ -6,6 +6,8 @@ import net.minecraft.resource.Identifier;
 
 public interface IServerPlayNetworkHandler {
 
+	boolean osl$networking$isPlayReady();
+
 	void osl$networking$registerClientChannels(Set<Identifier> channels);
 
 	boolean osl$networking$isRegisteredClientChannel(Identifier channel);

--- a/libraries/networking/networking-mc1.13-pre4-mc18w30b/src/main/java/net/ornithemc/osl/networking/impl/mixin/client/ClientPlayNetworkHandlerMixin.java
+++ b/libraries/networking/networking-mc1.13-pre4-mc18w30b/src/main/java/net/ornithemc/osl/networking/impl/mixin/client/ClientPlayNetworkHandlerMixin.java
@@ -9,6 +9,7 @@ import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.At.Shift;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 import net.minecraft.client.Minecraft;
@@ -18,7 +19,7 @@ import net.minecraft.resource.Identifier;
 
 import net.ornithemc.osl.networking.api.client.ClientConnectionEvents;
 import net.ornithemc.osl.networking.impl.CommonChannels;
-import net.ornithemc.osl.networking.impl.NetworkingInitializer;
+import net.ornithemc.osl.networking.impl.Networking;
 import net.ornithemc.osl.networking.impl.client.ClientPlayNetworkingImpl;
 import net.ornithemc.osl.networking.impl.interfaces.mixin.IClientPlayNetworkHandler;
 
@@ -30,7 +31,22 @@ public class ClientPlayNetworkHandlerMixin implements IClientPlayNetworkHandler 
 	/**
 	 * Channels that the server is listening to.
 	 */
-	@Unique private final Set<Identifier> serverChannels = new LinkedHashSet<>();
+	@Unique private Set<Identifier> serverChannels;
+
+	@Inject(
+		method = "handleLogin",
+		at = @At(
+			value = "INVOKE",
+			shift = Shift.AFTER,
+			target = "Lnet/minecraft/network/PacketUtils;ensureOnSameThread(Lnet/minecraft/network/packet/Packet;Lnet/minecraft/network/handler/PacketHandler;Lnet/minecraft/util/BlockableEventLoop;)V"
+		)
+	)
+	private void osl$networking$registerChannels(CallbackInfo ci) {
+		// send channel registration data as soon as login occurs
+		ClientPlayNetworkingImpl.doSend(CommonChannels.CHANNELS, data -> {
+			Networking.writeChannels(data, ClientPlayNetworkingImpl.LISTENERS.keySet());
+		});
+	}
 
 	@Inject(
 		method = "handleLogin",
@@ -39,10 +55,6 @@ public class ClientPlayNetworkHandlerMixin implements IClientPlayNetworkHandler 
 		)
 	)
 	private void osl$networking$handleLogin(CallbackInfo ci) {
-		ClientPlayNetworkingImpl.doSend(CommonChannels.CHANNELS, data -> {
-			NetworkingInitializer.writeChannels(data, ClientPlayNetworkingImpl.LISTENERS.keySet());
-		});
-
 		ClientConnectionEvents.LOGIN.invoker().accept(minecraft);
 	}
 
@@ -54,7 +66,7 @@ public class ClientPlayNetworkHandlerMixin implements IClientPlayNetworkHandler 
 	)
 	private void osl$networking$handleDisconnect(CallbackInfo ci) {
 		ClientConnectionEvents.DISCONNECT.invoker().accept(minecraft);
-		serverChannels.clear();
+		serverChannels = null;
 	}
 
 	@Inject(
@@ -71,8 +83,13 @@ public class ClientPlayNetworkHandlerMixin implements IClientPlayNetworkHandler 
 	}
 
 	@Override
+	public boolean osl$networking$isPlayReady() {
+		return serverChannels != null;
+	}
+
+	@Override
 	public void osl$networking$registerServerChannels(Set<Identifier> channels) {
-		serverChannels.addAll(channels);
+		serverChannels = new LinkedHashSet<>(channels);
 	}
 
 	@Override

--- a/libraries/networking/networking-mc1.13-pre4-mc18w30b/src/main/java/net/ornithemc/osl/networking/impl/mixin/client/ClientPlayNetworkHandlerMixin.java
+++ b/libraries/networking/networking-mc1.13-pre4-mc18w30b/src/main/java/net/ornithemc/osl/networking/impl/mixin/client/ClientPlayNetworkHandlerMixin.java
@@ -83,6 +83,6 @@ public class ClientPlayNetworkHandlerMixin implements IClientPlayNetworkHandler 
 
 	@Override
 	public boolean osl$networking$isRegisteredServerChannel(Identifier channel) {
-		return serverChannels.contains(channel);
+		return serverChannels != null && serverChannels.contains(channel);
 	}
 }

--- a/libraries/networking/networking-mc1.13-pre4-mc18w30b/src/main/java/net/ornithemc/osl/networking/impl/mixin/client/ClientPlayNetworkHandlerMixin.java
+++ b/libraries/networking/networking-mc1.13-pre4-mc18w30b/src/main/java/net/ornithemc/osl/networking/impl/mixin/client/ClientPlayNetworkHandlerMixin.java
@@ -9,7 +9,6 @@ import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.At.Shift;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 import net.minecraft.client.Minecraft;
@@ -36,25 +35,15 @@ public class ClientPlayNetworkHandlerMixin implements IClientPlayNetworkHandler 
 	@Inject(
 		method = "handleLogin",
 		at = @At(
-			value = "INVOKE",
-			shift = Shift.AFTER,
-			target = "Lnet/minecraft/network/PacketUtils;ensureOnSameThread(Lnet/minecraft/network/packet/Packet;Lnet/minecraft/network/handler/PacketHandler;Lnet/minecraft/util/BlockableEventLoop;)V"
-		)
-	)
-	private void osl$networking$registerChannels(CallbackInfo ci) {
-		// send channel registration data as soon as login occurs
-		ClientPlayNetworkingImpl.doSend(CommonChannels.CHANNELS, data -> {
-			Networking.writeChannels(data, ClientPlayNetworkingImpl.LISTENERS.keySet());
-		});
-	}
-
-	@Inject(
-		method = "handleLogin",
-		at = @At(
 			value = "TAIL"
 		)
 	)
 	private void osl$networking$handleLogin(CallbackInfo ci) {
+		// send channel registration data as soon as login occurs
+		ClientPlayNetworkingImpl.doSend(CommonChannels.CHANNELS, data -> {
+			Networking.writeChannels(data, ClientPlayNetworkingImpl.LISTENERS.keySet());
+		});
+
 		ClientConnectionEvents.LOGIN.invoker().accept(minecraft);
 	}
 

--- a/libraries/networking/networking-mc1.13-pre4-mc18w30b/src/main/java/net/ornithemc/osl/networking/impl/mixin/common/PlayerManagerMixin.java
+++ b/libraries/networking/networking-mc1.13-pre4-mc18w30b/src/main/java/net/ornithemc/osl/networking/impl/mixin/common/PlayerManagerMixin.java
@@ -14,7 +14,7 @@ import net.minecraft.server.entity.living.player.ServerPlayerEntity;
 
 import net.ornithemc.osl.networking.api.server.ServerConnectionEvents;
 import net.ornithemc.osl.networking.impl.CommonChannels;
-import net.ornithemc.osl.networking.impl.NetworkingInitializer;
+import net.ornithemc.osl.networking.impl.Networking;
 import net.ornithemc.osl.networking.impl.server.ServerPlayNetworkingImpl;
 
 @Mixin(PlayerManager.class)
@@ -30,8 +30,9 @@ public class PlayerManagerMixin {
 		)
 	)
 	private void osl$networking$registerChannels(Connection connection, ServerPlayerEntity player, CallbackInfo ci) {
+		// send channel registration data as soon as login occurs
 		ServerPlayNetworkingImpl.doSend(player, CommonChannels.CHANNELS, data -> {
-			NetworkingInitializer.writeChannels(data, ServerPlayNetworkingImpl.LISTENERS.keySet());
+			Networking.writeChannels(data, ServerPlayNetworkingImpl.LISTENERS.keySet());
 		});
 	}
 

--- a/libraries/networking/networking-mc1.13-pre4-mc18w30b/src/main/java/net/ornithemc/osl/networking/impl/mixin/common/PlayerManagerMixin.java
+++ b/libraries/networking/networking-mc1.13-pre4-mc18w30b/src/main/java/net/ornithemc/osl/networking/impl/mixin/common/PlayerManagerMixin.java
@@ -13,28 +13,11 @@ import net.minecraft.server.PlayerManager;
 import net.minecraft.server.entity.living.player.ServerPlayerEntity;
 
 import net.ornithemc.osl.networking.api.server.ServerConnectionEvents;
-import net.ornithemc.osl.networking.impl.CommonChannels;
-import net.ornithemc.osl.networking.impl.Networking;
-import net.ornithemc.osl.networking.impl.server.ServerPlayNetworkingImpl;
 
 @Mixin(PlayerManager.class)
 public class PlayerManagerMixin {
 
 	@Shadow @Final private MinecraftServer server;
-
-	@Inject(
-		method = "onLogin",
-		at = @At(
-			value = "NEW",
-			target = "Lnet/minecraft/network/packet/s2c/play/LoginS2CPacket;"
-		)
-	)
-	private void osl$networking$registerChannels(Connection connection, ServerPlayerEntity player, CallbackInfo ci) {
-		// send channel registration data as soon as login occurs
-		ServerPlayNetworkingImpl.doSend(player, CommonChannels.CHANNELS, data -> {
-			Networking.writeChannels(data, ServerPlayNetworkingImpl.LISTENERS.keySet());
-		});
-	}
 
 	@Inject(
 		method = "onLogin",

--- a/libraries/networking/networking-mc1.13-pre4-mc18w30b/src/main/java/net/ornithemc/osl/networking/impl/mixin/common/ServerPlayNetworkHandlerMixin.java
+++ b/libraries/networking/networking-mc1.13-pre4-mc18w30b/src/main/java/net/ornithemc/osl/networking/impl/mixin/common/ServerPlayNetworkHandlerMixin.java
@@ -30,7 +30,7 @@ public class ServerPlayNetworkHandlerMixin implements IServerPlayNetworkHandler 
 	/**
 	 * Channels that the client is listening to.
 	 */
-	@Unique private final Set<Identifier> clientChannels = new LinkedHashSet<>();
+	@Unique private Set<Identifier> clientChannels;
 
 	@Inject(
 		method = "onDisconnect",
@@ -40,7 +40,7 @@ public class ServerPlayNetworkHandlerMixin implements IServerPlayNetworkHandler 
 	)
 	private void osl$networking$handleDisconnect(CallbackInfo ci) {
 		ServerConnectionEvents.DISCONNECT.invoker().accept(server, player);
-		clientChannels.clear();
+		clientChannels = null;
 	}
 
 	@Inject(
@@ -57,8 +57,13 @@ public class ServerPlayNetworkHandlerMixin implements IServerPlayNetworkHandler 
 	}
 
 	@Override
+	public boolean osl$networking$isPlayReady() {
+		return clientChannels != null;
+	}
+
+	@Override
 	public void osl$networking$registerClientChannels(Set<Identifier> channels) {
-		clientChannels.addAll(channels);
+		clientChannels = new LinkedHashSet<>(channels);
 	}
 
 	@Override

--- a/libraries/networking/networking-mc1.13-pre4-mc18w30b/src/main/java/net/ornithemc/osl/networking/impl/mixin/common/ServerPlayNetworkHandlerMixin.java
+++ b/libraries/networking/networking-mc1.13-pre4-mc18w30b/src/main/java/net/ornithemc/osl/networking/impl/mixin/common/ServerPlayNetworkHandlerMixin.java
@@ -68,6 +68,6 @@ public class ServerPlayNetworkHandlerMixin implements IServerPlayNetworkHandler 
 
 	@Override
 	public boolean osl$networking$isRegisteredClientChannel(Identifier channel) {
-		return clientChannels.contains(channel);
+		return clientChannels != null && clientChannels.contains(channel);
 	}
 }

--- a/libraries/networking/networking-mc1.13-pre4-mc18w30b/src/main/java/net/ornithemc/osl/networking/impl/server/ServerPlayNetworkingImpl.java
+++ b/libraries/networking/networking-mc1.13-pre4-mc18w30b/src/main/java/net/ornithemc/osl/networking/impl/server/ServerPlayNetworkingImpl.java
@@ -84,8 +84,14 @@ public final class ServerPlayNetworkingImpl {
 		return false;
 	}
 
+	public static boolean isPlayReady(ServerPlayerEntity player) {
+		IServerPlayNetworkHandler handler = (IServerPlayNetworkHandler)player.networkHandler;
+		return handler != null && handler.osl$networking$isPlayReady();
+	}
+
 	public static boolean canSend(ServerPlayerEntity player, Identifier channel) {
-		return ((IServerPlayNetworkHandler)player.networkHandler).osl$networking$isRegisteredClientChannel(channel);
+		IServerPlayNetworkHandler handler = (IServerPlayNetworkHandler)player.networkHandler;
+		return handler != null && handler.osl$networking$isRegisteredClientChannel(channel);
 	}
 
 	public static void send(ServerPlayerEntity player, Identifier channel, Consumer<PacketByteBuf> writer) {

--- a/libraries/networking/networking-mc1.3-pre-07261249-mc1.5.2/src/main/java/net/ornithemc/osl/networking/api/client/ClientConnectionEvents.java
+++ b/libraries/networking/networking-mc1.3-pre-07261249-mc1.5.2/src/main/java/net/ornithemc/osl/networking/api/client/ClientConnectionEvents.java
@@ -10,10 +10,19 @@ public class ClientConnectionEvents {
 
 	/**
 	 * This event is fired after a successful login occurs.
+	 * Note that channel registration happens after login,
+	 * and until then data cannot safely be sent to the server.
 	 * This applies to connections to dedicated servers as
 	 * well as connections to integrated servers.
 	 */
 	public static final Event<Consumer<Minecraft>> LOGIN = Event.consumer();
+	/**
+	 * This event is fired after login, once channel registration is complete.
+	 * This marks the moment data can safely be sent to the server.
+	 * This applies to connections to dedicated servers as
+	 * well as connections to integrated servers.
+	 */
+	public static final Event<Consumer<Minecraft>> PLAY_READY = Event.consumer();
 	/**
 	 * This event is fired when the client disconnects from the server.
 	 * This applies to connections to dedicated servers as

--- a/libraries/networking/networking-mc1.3-pre-07261249-mc1.5.2/src/main/java/net/ornithemc/osl/networking/api/client/ClientPlayNetworking.java
+++ b/libraries/networking/networking-mc1.3-pre-07261249-mc1.5.2/src/main/java/net/ornithemc/osl/networking/api/client/ClientPlayNetworking.java
@@ -36,6 +36,13 @@ public final class ClientPlayNetworking {
 	}
 
 	/**
+	 * Check whether the connection is ready for data to be sent to the server.
+	 */
+	public static boolean isPlayReady() {
+		return ClientPlayNetworkingImpl.isPlayReady();
+	}
+
+	/**
 	 * Check whether the given channel is open for data to be sent through it.
 	 * This method will return {@code false} if the client is not connected to a
 	 * server, or if the server has no listeners for the given channel.

--- a/libraries/networking/networking-mc1.3-pre-07261249-mc1.5.2/src/main/java/net/ornithemc/osl/networking/api/server/ServerConnectionEvents.java
+++ b/libraries/networking/networking-mc1.3-pre-07261249-mc1.5.2/src/main/java/net/ornithemc/osl/networking/api/server/ServerConnectionEvents.java
@@ -11,10 +11,19 @@ public class ServerConnectionEvents {
 
 	/**
 	 * This event is fired after a successful login occurs.
+	 * Note that channel registration happens after login,
+	 * and until then data cannot safely be sent to the client.
 	 * This applies to connections to dedicated servers as
 	 * well as connections to integrated servers.
 	 */
 	public static final Event<BiConsumer<MinecraftServer, ServerPlayerEntity>> LOGIN = Event.biConsumer();
+	/**
+	 * This event is fired after login, once channel registration is complete.
+	 * This marks the moment data can safely be sent to the client.
+	 * This applies to connections to dedicated servers as
+	 * well as connections to integrated servers.
+	 */
+	public static final Event<BiConsumer<MinecraftServer, ServerPlayerEntity>> PLAY_READY = Event.biConsumer();
 	/**
 	 * This event is fired when a client disconnects from the server.
 	 * This applies to connections to dedicated servers as

--- a/libraries/networking/networking-mc1.3-pre-07261249-mc1.5.2/src/main/java/net/ornithemc/osl/networking/api/server/ServerPlayNetworking.java
+++ b/libraries/networking/networking-mc1.3-pre-07261249-mc1.5.2/src/main/java/net/ornithemc/osl/networking/api/server/ServerPlayNetworking.java
@@ -37,6 +37,13 @@ public final class ServerPlayNetworking {
 	}
 
 	/**
+	 * Check whether the connection is ready for data to be sent to the client.
+	 */
+	public static boolean isPlayReady(ServerPlayerEntity player) {
+		return ServerPlayNetworkingImpl.isPlayReady(player);
+	}
+
+	/**
 	 * Check whether the given channel is open for data to be sent through it.
 	 * This method will return {@code false} if the client has no listeners for
 	 * the given channel.

--- a/libraries/networking/networking-mc1.3-pre-07261249-mc1.5.2/src/main/java/net/ornithemc/osl/networking/impl/Networking.java
+++ b/libraries/networking/networking-mc1.3-pre-07261249-mc1.5.2/src/main/java/net/ornithemc/osl/networking/impl/Networking.java
@@ -32,6 +32,11 @@ public class Networking implements ModInitializer, ClientModInitializer {
 			ServerPlayNetworkingImpl.destroy(server);
 		});
 		ServerPlayNetworking.registerListener(CommonChannels.CHANNELS, (server, handler, player, data) -> {
+			// send channel registration data as a response to receiving client channel registration data
+			ServerPlayNetworkingImpl.doSend(player, CommonChannels.CHANNELS, response -> {
+				Networking.writeChannels(response, ServerPlayNetworkingImpl.LISTENERS.keySet());
+			});
+
 			((IServerPlayNetworkHandler)handler).osl$networking$registerClientChannels(readChannels(data));
 			ServerConnectionEvents.PLAY_READY.invoker().accept(server, player);
 

--- a/libraries/networking/networking-mc1.3-pre-07261249-mc1.5.2/src/main/java/net/ornithemc/osl/networking/impl/Networking.java
+++ b/libraries/networking/networking-mc1.3-pre-07261249-mc1.5.2/src/main/java/net/ornithemc/osl/networking/impl/Networking.java
@@ -12,14 +12,16 @@ import net.ornithemc.osl.entrypoints.api.ModInitializer;
 import net.ornithemc.osl.entrypoints.api.client.ClientModInitializer;
 import net.ornithemc.osl.lifecycle.api.client.MinecraftClientEvents;
 import net.ornithemc.osl.lifecycle.api.server.MinecraftServerEvents;
+import net.ornithemc.osl.networking.api.client.ClientConnectionEvents;
 import net.ornithemc.osl.networking.api.client.ClientPlayNetworking;
+import net.ornithemc.osl.networking.api.server.ServerConnectionEvents;
 import net.ornithemc.osl.networking.api.server.ServerPlayNetworking;
 import net.ornithemc.osl.networking.impl.client.ClientPlayNetworkingImpl;
 import net.ornithemc.osl.networking.impl.interfaces.mixin.IClientNetworkHandler;
 import net.ornithemc.osl.networking.impl.interfaces.mixin.IServerPlayNetworkHandler;
 import net.ornithemc.osl.networking.impl.server.ServerPlayNetworkingImpl;
 
-public class NetworkingInitializer implements ModInitializer, ClientModInitializer {
+public class Networking implements ModInitializer, ClientModInitializer {
 
 	@Override
 	public void init() {
@@ -30,11 +32,8 @@ public class NetworkingInitializer implements ModInitializer, ClientModInitializ
 			ServerPlayNetworkingImpl.destroy(server);
 		});
 		ServerPlayNetworking.registerListener(CommonChannels.CHANNELS, (server, handler, player, data) -> {
-			Set<String> channels = readChannels(data);
-
-			if (!channels.isEmpty()) {
-				((IServerPlayNetworkHandler)handler).osl$networking$registerClientChannels(channels);
-			}
+			((IServerPlayNetworkHandler)handler).osl$networking$registerClientChannels(readChannels(data));
+			ServerConnectionEvents.PLAY_READY.invoker().accept(server, player);
 
 			return true;
 		});
@@ -49,11 +48,8 @@ public class NetworkingInitializer implements ModInitializer, ClientModInitializ
 			ClientPlayNetworkingImpl.destroy(minecraft);
 		});
 		ClientPlayNetworking.registerListener(CommonChannels.CHANNELS, (minecraft, handler, data) -> {
-			Set<String> channels = readChannels(data);
-
-			if (!channels.isEmpty()) {
-				((IClientNetworkHandler)handler).osl$networking$registerServerChannels(channels);
-			}
+			((IClientNetworkHandler)handler).osl$networking$registerServerChannels(readChannels(data));
+			ClientConnectionEvents.PLAY_READY.invoker().accept(minecraft);
 
 			return true;
 		});

--- a/libraries/networking/networking-mc1.3-pre-07261249-mc1.5.2/src/main/java/net/ornithemc/osl/networking/impl/client/ClientPlayNetworkingImpl.java
+++ b/libraries/networking/networking-mc1.3-pre-07261249-mc1.5.2/src/main/java/net/ornithemc/osl/networking/impl/client/ClientPlayNetworkingImpl.java
@@ -79,6 +79,11 @@ public final class ClientPlayNetworkingImpl {
 		return false;
 	}
 
+	public static boolean isPlayReady() {
+		IClientNetworkHandler handler = (IClientNetworkHandler)minecraft.getNetworkHandler();
+		return handler != null && handler.osl$networking$isPlayReady();
+	}
+
 	public static boolean canSend(String channel) {
 		IClientNetworkHandler handler = (IClientNetworkHandler)minecraft.getNetworkHandler();
 		return handler != null && handler.osl$networking$isRegisteredServerChannel(channel);

--- a/libraries/networking/networking-mc1.3-pre-07261249-mc1.5.2/src/main/java/net/ornithemc/osl/networking/impl/interfaces/mixin/IClientNetworkHandler.java
+++ b/libraries/networking/networking-mc1.3-pre-07261249-mc1.5.2/src/main/java/net/ornithemc/osl/networking/impl/interfaces/mixin/IClientNetworkHandler.java
@@ -4,6 +4,8 @@ import java.util.Set;
 
 public interface IClientNetworkHandler {
 
+	boolean osl$networking$isPlayReady();
+
 	void osl$networking$registerServerChannels(Set<String> channels);
 
 	boolean osl$networking$isRegisteredServerChannel(String channel);

--- a/libraries/networking/networking-mc1.3-pre-07261249-mc1.5.2/src/main/java/net/ornithemc/osl/networking/impl/interfaces/mixin/IServerPlayNetworkHandler.java
+++ b/libraries/networking/networking-mc1.3-pre-07261249-mc1.5.2/src/main/java/net/ornithemc/osl/networking/impl/interfaces/mixin/IServerPlayNetworkHandler.java
@@ -4,6 +4,8 @@ import java.util.Set;
 
 public interface IServerPlayNetworkHandler {
 
+	boolean osl$networking$isPlayReady();
+
 	void osl$networking$registerClientChannels(Set<String> channels);
 
 	boolean osl$networking$isRegisteredClientChannel(String channel);

--- a/libraries/networking/networking-mc1.3-pre-07261249-mc1.5.2/src/main/java/net/ornithemc/osl/networking/impl/mixin/client/ClientNetworkHandlerMixin.java
+++ b/libraries/networking/networking-mc1.3-pre-07261249-mc1.5.2/src/main/java/net/ornithemc/osl/networking/impl/mixin/client/ClientNetworkHandlerMixin.java
@@ -34,23 +34,15 @@ public class ClientNetworkHandlerMixin implements IClientNetworkHandler {
 	@Inject(
 		method = "handleLogin",
 		at = @At(
-			value = "HEAD"
-		)
-	)
-	private void osl$networking$registerChannels(CallbackInfo ci) {
-		// send channel registration data as soon as login occurs
-		ClientPlayNetworkingImpl.doSend(CommonChannels.CHANNELS, data -> {
-			Networking.writeChannels(data, ClientPlayNetworkingImpl.LISTENERS.keySet());
-		});
-	}
-
-	@Inject(
-		method = "handleLogin",
-		at = @At(
 			value = "TAIL"
 		)
 	)
 	private void osl$networking$handleLogin(CallbackInfo ci) {
+		// send channel registration data as soon as login occurs
+		ClientPlayNetworkingImpl.doSend(CommonChannels.CHANNELS, data -> {
+			Networking.writeChannels(data, ClientPlayNetworkingImpl.LISTENERS.keySet());
+		});
+
 		ClientConnectionEvents.LOGIN.invoker().accept(minecraft);
 	}
 

--- a/libraries/networking/networking-mc1.3-pre-07261249-mc1.5.2/src/main/java/net/ornithemc/osl/networking/impl/mixin/client/ClientNetworkHandlerMixin.java
+++ b/libraries/networking/networking-mc1.3-pre-07261249-mc1.5.2/src/main/java/net/ornithemc/osl/networking/impl/mixin/client/ClientNetworkHandlerMixin.java
@@ -82,6 +82,6 @@ public class ClientNetworkHandlerMixin implements IClientNetworkHandler {
 
 	@Override
 	public boolean osl$networking$isRegisteredServerChannel(String channel) {
-		return serverChannels.contains(channel);
+		return serverChannels != null && serverChannels.contains(channel);
 	}
 }

--- a/libraries/networking/networking-mc1.3-pre-07261249-mc1.5.2/src/main/java/net/ornithemc/osl/networking/impl/mixin/common/PlayerManagerMixin.java
+++ b/libraries/networking/networking-mc1.3-pre-07261249-mc1.5.2/src/main/java/net/ornithemc/osl/networking/impl/mixin/common/PlayerManagerMixin.java
@@ -14,7 +14,7 @@ import net.minecraft.server.entity.living.player.ServerPlayerEntity;
 
 import net.ornithemc.osl.networking.api.server.ServerConnectionEvents;
 import net.ornithemc.osl.networking.impl.CommonChannels;
-import net.ornithemc.osl.networking.impl.NetworkingInitializer;
+import net.ornithemc.osl.networking.impl.Networking;
 import net.ornithemc.osl.networking.impl.server.ServerPlayNetworkingImpl;
 
 @Mixin(PlayerManager.class)
@@ -30,8 +30,9 @@ public class PlayerManagerMixin {
 		)
 	)
 	private void osl$networking$registerChannels(Connection connection, ServerPlayerEntity player, CallbackInfo ci) {
+		// send channel registration data as soon as login occurs
 		ServerPlayNetworkingImpl.doSend(player, CommonChannels.CHANNELS, data -> {
-			NetworkingInitializer.writeChannels(data, ServerPlayNetworkingImpl.LISTENERS.keySet());
+			Networking.writeChannels(data, ServerPlayNetworkingImpl.LISTENERS.keySet());
 		});
 	}
 

--- a/libraries/networking/networking-mc1.3-pre-07261249-mc1.5.2/src/main/java/net/ornithemc/osl/networking/impl/mixin/common/PlayerManagerMixin.java
+++ b/libraries/networking/networking-mc1.3-pre-07261249-mc1.5.2/src/main/java/net/ornithemc/osl/networking/impl/mixin/common/PlayerManagerMixin.java
@@ -13,28 +13,11 @@ import net.minecraft.server.PlayerManager;
 import net.minecraft.server.entity.living.player.ServerPlayerEntity;
 
 import net.ornithemc.osl.networking.api.server.ServerConnectionEvents;
-import net.ornithemc.osl.networking.impl.CommonChannels;
-import net.ornithemc.osl.networking.impl.Networking;
-import net.ornithemc.osl.networking.impl.server.ServerPlayNetworkingImpl;
 
 @Mixin(PlayerManager.class)
 public class PlayerManagerMixin {
 
 	@Shadow @Final private MinecraftServer server;
-
-	@Inject(
-		method = "onLogin",
-		at = @At(
-			value = "NEW",
-			target = "Lnet/minecraft/network/packet/LoginPacket;"
-		)
-	)
-	private void osl$networking$registerChannels(Connection connection, ServerPlayerEntity player, CallbackInfo ci) {
-		// send channel registration data as soon as login occurs
-		ServerPlayNetworkingImpl.doSend(player, CommonChannels.CHANNELS, data -> {
-			Networking.writeChannels(data, ServerPlayNetworkingImpl.LISTENERS.keySet());
-		});
-	}
 
 	@Inject(
 		method = "onLogin",

--- a/libraries/networking/networking-mc1.3-pre-07261249-mc1.5.2/src/main/java/net/ornithemc/osl/networking/impl/mixin/common/ServerPlayNetworkHandlerMixin.java
+++ b/libraries/networking/networking-mc1.3-pre-07261249-mc1.5.2/src/main/java/net/ornithemc/osl/networking/impl/mixin/common/ServerPlayNetworkHandlerMixin.java
@@ -67,6 +67,6 @@ public class ServerPlayNetworkHandlerMixin implements IServerPlayNetworkHandler 
 
 	@Override
 	public boolean osl$networking$isRegisteredClientChannel(String channel) {
-		return clientChannels.contains(channel);
+		return clientChannels != null && clientChannels.contains(channel);
 	}
 }

--- a/libraries/networking/networking-mc1.3-pre-07261249-mc1.5.2/src/main/java/net/ornithemc/osl/networking/impl/mixin/common/ServerPlayNetworkHandlerMixin.java
+++ b/libraries/networking/networking-mc1.3-pre-07261249-mc1.5.2/src/main/java/net/ornithemc/osl/networking/impl/mixin/common/ServerPlayNetworkHandlerMixin.java
@@ -29,7 +29,7 @@ public class ServerPlayNetworkHandlerMixin implements IServerPlayNetworkHandler 
 	/**
 	 * Channels that the client is listening to.
 	 */
-	@Unique private final Set<String> clientChannels = new LinkedHashSet<>();
+	@Unique private Set<String> clientChannels;
 
 	@Inject(
 		method = "onDisconnect",
@@ -39,7 +39,7 @@ public class ServerPlayNetworkHandlerMixin implements IServerPlayNetworkHandler 
 	)
 	private void osl$networking$handleDisconnect(CallbackInfo ci) {
 		ServerConnectionEvents.DISCONNECT.invoker().accept(server, player);
-		clientChannels.clear();
+		clientChannels = null;
 	}
 
 	@Inject(
@@ -56,8 +56,13 @@ public class ServerPlayNetworkHandlerMixin implements IServerPlayNetworkHandler 
 	}
 
 	@Override
+	public boolean osl$networking$isPlayReady() {
+		return clientChannels != null;
+	}
+
+	@Override
 	public void osl$networking$registerClientChannels(Set<String> channels) {
-		clientChannels.addAll(channels);
+		clientChannels = new LinkedHashSet<>(channels);
 	}
 
 	@Override

--- a/libraries/networking/networking-mc1.3-pre-07261249-mc1.5.2/src/main/java/net/ornithemc/osl/networking/impl/server/ServerPlayNetworkingImpl.java
+++ b/libraries/networking/networking-mc1.3-pre-07261249-mc1.5.2/src/main/java/net/ornithemc/osl/networking/impl/server/ServerPlayNetworkingImpl.java
@@ -83,8 +83,14 @@ public final class ServerPlayNetworkingImpl {
 		return false;
 	}
 
+	public static boolean isPlayReady(ServerPlayerEntity player) {
+		IServerPlayNetworkHandler handler = (IServerPlayNetworkHandler)player.networkHandler;
+		return handler != null && handler.osl$networking$isPlayReady();
+	}
+
 	public static boolean canSend(ServerPlayerEntity player, String channel) {
-		return ((IServerPlayNetworkHandler)player.networkHandler).osl$networking$isRegisteredClientChannel(channel);
+		IServerPlayNetworkHandler handler = (IServerPlayNetworkHandler)player.networkHandler;
+		return handler != null && handler.osl$networking$isRegisteredClientChannel(channel);
 	}
 
 	public static void send(ServerPlayerEntity player, String channel, IOConsumer<DataOutputStream> writer) {

--- a/libraries/networking/networking-mc13w16a-04192037-mc13w39b/src/main/java/net/ornithemc/osl/networking/api/client/ClientConnectionEvents.java
+++ b/libraries/networking/networking-mc13w16a-04192037-mc13w39b/src/main/java/net/ornithemc/osl/networking/api/client/ClientConnectionEvents.java
@@ -10,10 +10,19 @@ public class ClientConnectionEvents {
 
 	/**
 	 * This event is fired after a successful login occurs.
+	 * Note that channel registration happens after login,
+	 * and until then data cannot safely be sent to the server.
 	 * This applies to connections to dedicated servers as
 	 * well as connections to integrated servers.
 	 */
 	public static final Event<Consumer<Minecraft>> LOGIN = Event.consumer();
+	/**
+	 * This event is fired after login, once channel registration is complete.
+	 * This marks the moment data can safely be sent to the server.
+	 * This applies to connections to dedicated servers as
+	 * well as connections to integrated servers.
+	 */
+	public static final Event<Consumer<Minecraft>> PLAY_READY = Event.consumer();
 	/**
 	 * This event is fired when the client disconnects from the server.
 	 * This applies to connections to dedicated servers as

--- a/libraries/networking/networking-mc13w16a-04192037-mc13w39b/src/main/java/net/ornithemc/osl/networking/api/client/ClientPlayNetworking.java
+++ b/libraries/networking/networking-mc13w16a-04192037-mc13w39b/src/main/java/net/ornithemc/osl/networking/api/client/ClientPlayNetworking.java
@@ -36,6 +36,13 @@ public final class ClientPlayNetworking {
 	}
 
 	/**
+	 * Check whether the connection is ready for data to be sent to the server.
+	 */
+	public static boolean isPlayReady() {
+		return ClientPlayNetworkingImpl.isPlayReady();
+	}
+
+	/**
 	 * Check whether the given channel is open for data to be sent through it.
 	 * This method will return {@code false} if the client is not connected to a
 	 * server, or if the server has no listeners for the given channel.

--- a/libraries/networking/networking-mc13w16a-04192037-mc13w39b/src/main/java/net/ornithemc/osl/networking/api/server/ServerConnectionEvents.java
+++ b/libraries/networking/networking-mc13w16a-04192037-mc13w39b/src/main/java/net/ornithemc/osl/networking/api/server/ServerConnectionEvents.java
@@ -11,10 +11,19 @@ public class ServerConnectionEvents {
 
 	/**
 	 * This event is fired after a successful login occurs.
+	 * Note that channel registration happens after login,
+	 * and until then data cannot safely be sent to the client.
 	 * This applies to connections to dedicated servers as
 	 * well as connections to integrated servers.
 	 */
 	public static final Event<BiConsumer<MinecraftServer, ServerPlayerEntity>> LOGIN = Event.biConsumer();
+	/**
+	 * This event is fired after login, once channel registration is complete.
+	 * This marks the moment data can safely be sent to the client.
+	 * This applies to connections to dedicated servers as
+	 * well as connections to integrated servers.
+	 */
+	public static final Event<BiConsumer<MinecraftServer, ServerPlayerEntity>> PLAY_READY = Event.biConsumer();
 	/**
 	 * This event is fired when a client disconnects from the server.
 	 * This applies to connections to dedicated servers as

--- a/libraries/networking/networking-mc13w16a-04192037-mc13w39b/src/main/java/net/ornithemc/osl/networking/api/server/ServerPlayNetworking.java
+++ b/libraries/networking/networking-mc13w16a-04192037-mc13w39b/src/main/java/net/ornithemc/osl/networking/api/server/ServerPlayNetworking.java
@@ -37,6 +37,13 @@ public final class ServerPlayNetworking {
 	}
 
 	/**
+	 * Check whether the connection is ready for data to be sent to the client.
+	 */
+	public static boolean isPlayReady(ServerPlayerEntity player) {
+		return ServerPlayNetworkingImpl.isPlayReady(player);
+	}
+
+	/**
 	 * Check whether the given channel is open for data to be sent through it.
 	 * This method will return {@code false} if the client has no listeners for
 	 * the given channel.

--- a/libraries/networking/networking-mc13w16a-04192037-mc13w39b/src/main/java/net/ornithemc/osl/networking/impl/Networking.java
+++ b/libraries/networking/networking-mc13w16a-04192037-mc13w39b/src/main/java/net/ornithemc/osl/networking/impl/Networking.java
@@ -32,6 +32,11 @@ public class Networking implements ModInitializer, ClientModInitializer {
 			ServerPlayNetworkingImpl.destroy(server);
 		});
 		ServerPlayNetworking.registerListener(CommonChannels.CHANNELS, (server, handler, player, data) -> {
+			// send channel registration data as a response to receiving client channel registration data
+			ServerPlayNetworkingImpl.doSend(player, CommonChannels.CHANNELS, response -> {
+				Networking.writeChannels(response, ServerPlayNetworkingImpl.LISTENERS.keySet());
+			});
+
 			((IServerPlayNetworkHandler)handler).osl$networking$registerClientChannels(readChannels(data));
 			ServerConnectionEvents.PLAY_READY.invoker().accept(server, player);
 

--- a/libraries/networking/networking-mc13w16a-04192037-mc13w39b/src/main/java/net/ornithemc/osl/networking/impl/client/ClientPlayNetworkingImpl.java
+++ b/libraries/networking/networking-mc13w16a-04192037-mc13w39b/src/main/java/net/ornithemc/osl/networking/impl/client/ClientPlayNetworkingImpl.java
@@ -80,6 +80,11 @@ public final class ClientPlayNetworkingImpl {
 		return false;
 	}
 
+	public static boolean isPlayReady() {
+		IClientNetworkHandler handler = (IClientNetworkHandler)minecraft.getNetworkHandler();
+		return handler != null && handler.osl$networking$isPlayReady();
+	}
+
 	public static boolean canSend(String channel) {
 		IClientNetworkHandler handler = (IClientNetworkHandler)minecraft.getNetworkHandler();
 		return handler != null && handler.osl$networking$isRegisteredServerChannel(channel);

--- a/libraries/networking/networking-mc13w16a-04192037-mc13w39b/src/main/java/net/ornithemc/osl/networking/impl/interfaces/mixin/IClientNetworkHandler.java
+++ b/libraries/networking/networking-mc13w16a-04192037-mc13w39b/src/main/java/net/ornithemc/osl/networking/impl/interfaces/mixin/IClientNetworkHandler.java
@@ -4,6 +4,8 @@ import java.util.Set;
 
 public interface IClientNetworkHandler {
 
+	boolean osl$networking$isPlayReady();
+
 	void osl$networking$registerServerChannels(Set<String> channels);
 
 	boolean osl$networking$isRegisteredServerChannel(String channel);

--- a/libraries/networking/networking-mc13w16a-04192037-mc13w39b/src/main/java/net/ornithemc/osl/networking/impl/interfaces/mixin/IServerPlayNetworkHandler.java
+++ b/libraries/networking/networking-mc13w16a-04192037-mc13w39b/src/main/java/net/ornithemc/osl/networking/impl/interfaces/mixin/IServerPlayNetworkHandler.java
@@ -4,6 +4,8 @@ import java.util.Set;
 
 public interface IServerPlayNetworkHandler {
 
+	boolean osl$networking$isPlayReady();
+
 	void osl$networking$registerClientChannels(Set<String> channels);
 
 	boolean osl$networking$isRegisteredClientChannel(String channel);

--- a/libraries/networking/networking-mc13w16a-04192037-mc13w39b/src/main/java/net/ornithemc/osl/networking/impl/mixin/client/ClientNetworkHandlerMixin.java
+++ b/libraries/networking/networking-mc13w16a-04192037-mc13w39b/src/main/java/net/ornithemc/osl/networking/impl/mixin/client/ClientNetworkHandlerMixin.java
@@ -34,23 +34,15 @@ public class ClientNetworkHandlerMixin implements IClientNetworkHandler {
 	@Inject(
 		method = "handleLogin",
 		at = @At(
-			value = "HEAD"
-		)
-	)
-	private void osl$networking$registerChannels(CallbackInfo ci) {
-		// send channel registration data as soon as login occurs
-		ClientPlayNetworkingImpl.doSend(CommonChannels.CHANNELS, data -> {
-			Networking.writeChannels(data, ClientPlayNetworkingImpl.LISTENERS.keySet());
-		});
-	}
-
-	@Inject(
-		method = "handleLogin",
-		at = @At(
 			value = "TAIL"
 		)
 	)
 	private void osl$networking$handleLogin(CallbackInfo ci) {
+		// send channel registration data as soon as login occurs
+		ClientPlayNetworkingImpl.doSend(CommonChannels.CHANNELS, data -> {
+			Networking.writeChannels(data, ClientPlayNetworkingImpl.LISTENERS.keySet());
+		});
+
 		ClientConnectionEvents.LOGIN.invoker().accept(minecraft);
 	}
 

--- a/libraries/networking/networking-mc13w16a-04192037-mc13w39b/src/main/java/net/ornithemc/osl/networking/impl/mixin/client/ClientNetworkHandlerMixin.java
+++ b/libraries/networking/networking-mc13w16a-04192037-mc13w39b/src/main/java/net/ornithemc/osl/networking/impl/mixin/client/ClientNetworkHandlerMixin.java
@@ -82,6 +82,6 @@ public class ClientNetworkHandlerMixin implements IClientNetworkHandler {
 
 	@Override
 	public boolean osl$networking$isRegisteredServerChannel(String channel) {
-		return serverChannels.contains(channel);
+		return serverChannels != null && serverChannels.contains(channel);
 	}
 }

--- a/libraries/networking/networking-mc13w16a-04192037-mc13w39b/src/main/java/net/ornithemc/osl/networking/impl/mixin/common/PlayerManagerMixin.java
+++ b/libraries/networking/networking-mc13w16a-04192037-mc13w39b/src/main/java/net/ornithemc/osl/networking/impl/mixin/common/PlayerManagerMixin.java
@@ -14,7 +14,7 @@ import net.minecraft.server.entity.living.player.ServerPlayerEntity;
 
 import net.ornithemc.osl.networking.api.server.ServerConnectionEvents;
 import net.ornithemc.osl.networking.impl.CommonChannels;
-import net.ornithemc.osl.networking.impl.NetworkingInitializer;
+import net.ornithemc.osl.networking.impl.Networking;
 import net.ornithemc.osl.networking.impl.server.ServerPlayNetworkingImpl;
 
 @Mixin(PlayerManager.class)
@@ -30,8 +30,9 @@ public class PlayerManagerMixin {
 		)
 	)
 	private void osl$networking$registerChannels(Connection connection, ServerPlayerEntity player, CallbackInfo ci) {
+		// send channel registration data as soon as login occurs
 		ServerPlayNetworkingImpl.doSend(player, CommonChannels.CHANNELS, data -> {
-			NetworkingInitializer.writeChannels(data, ServerPlayNetworkingImpl.LISTENERS.keySet());
+			Networking.writeChannels(data, ServerPlayNetworkingImpl.LISTENERS.keySet());
 		});
 	}
 

--- a/libraries/networking/networking-mc13w16a-04192037-mc13w39b/src/main/java/net/ornithemc/osl/networking/impl/mixin/common/PlayerManagerMixin.java
+++ b/libraries/networking/networking-mc13w16a-04192037-mc13w39b/src/main/java/net/ornithemc/osl/networking/impl/mixin/common/PlayerManagerMixin.java
@@ -13,28 +13,11 @@ import net.minecraft.server.PlayerManager;
 import net.minecraft.server.entity.living.player.ServerPlayerEntity;
 
 import net.ornithemc.osl.networking.api.server.ServerConnectionEvents;
-import net.ornithemc.osl.networking.impl.CommonChannels;
-import net.ornithemc.osl.networking.impl.Networking;
-import net.ornithemc.osl.networking.impl.server.ServerPlayNetworkingImpl;
 
 @Mixin(PlayerManager.class)
 public class PlayerManagerMixin {
 
 	@Shadow @Final private MinecraftServer server;
-
-	@Inject(
-		method = "onLogin",
-		at = @At(
-			value = "NEW",
-			target = "Lnet/minecraft/network/packet/LoginPacket;"
-		)
-	)
-	private void osl$networking$registerChannels(Connection connection, ServerPlayerEntity player, CallbackInfo ci) {
-		// send channel registration data as soon as login occurs
-		ServerPlayNetworkingImpl.doSend(player, CommonChannels.CHANNELS, data -> {
-			Networking.writeChannels(data, ServerPlayNetworkingImpl.LISTENERS.keySet());
-		});
-	}
 
 	@Inject(
 		method = "onLogin",

--- a/libraries/networking/networking-mc13w16a-04192037-mc13w39b/src/main/java/net/ornithemc/osl/networking/impl/mixin/common/ServerPlayNetworkHandlerMixin.java
+++ b/libraries/networking/networking-mc13w16a-04192037-mc13w39b/src/main/java/net/ornithemc/osl/networking/impl/mixin/common/ServerPlayNetworkHandlerMixin.java
@@ -67,6 +67,6 @@ public class ServerPlayNetworkHandlerMixin implements IServerPlayNetworkHandler 
 
 	@Override
 	public boolean osl$networking$isRegisteredClientChannel(String channel) {
-		return clientChannels.contains(channel);
+		return clientChannels != null && clientChannels.contains(channel);
 	}
 }

--- a/libraries/networking/networking-mc13w16a-04192037-mc13w39b/src/main/java/net/ornithemc/osl/networking/impl/mixin/common/ServerPlayNetworkHandlerMixin.java
+++ b/libraries/networking/networking-mc13w16a-04192037-mc13w39b/src/main/java/net/ornithemc/osl/networking/impl/mixin/common/ServerPlayNetworkHandlerMixin.java
@@ -29,7 +29,7 @@ public class ServerPlayNetworkHandlerMixin implements IServerPlayNetworkHandler 
 	/**
 	 * Channels that the client is listening to.
 	 */
-	@Unique private final Set<String> clientChannels = new LinkedHashSet<>();
+	@Unique private Set<String> clientChannels;
 
 	@Inject(
 		method = "onDisconnect",
@@ -39,7 +39,7 @@ public class ServerPlayNetworkHandlerMixin implements IServerPlayNetworkHandler 
 	)
 	private void osl$networking$handleDisconnect(CallbackInfo ci) {
 		ServerConnectionEvents.DISCONNECT.invoker().accept(server, player);
-		clientChannels.clear();
+		clientChannels = null;
 	}
 
 	@Inject(
@@ -56,8 +56,13 @@ public class ServerPlayNetworkHandlerMixin implements IServerPlayNetworkHandler 
 	}
 
 	@Override
+	public boolean osl$networking$isPlayReady() {
+		return clientChannels != null;
+	}
+
+	@Override
 	public void osl$networking$registerClientChannels(Set<String> channels) {
-		clientChannels.addAll(channels);
+		clientChannels = new LinkedHashSet<>(channels);
 	}
 
 	@Override

--- a/libraries/networking/networking-mc13w16a-04192037-mc13w39b/src/main/java/net/ornithemc/osl/networking/impl/server/ServerPlayNetworkingImpl.java
+++ b/libraries/networking/networking-mc13w16a-04192037-mc13w39b/src/main/java/net/ornithemc/osl/networking/impl/server/ServerPlayNetworkingImpl.java
@@ -84,8 +84,14 @@ public final class ServerPlayNetworkingImpl {
 		return false;
 	}
 
+	public static boolean isPlayReady(ServerPlayerEntity player) {
+		IServerPlayNetworkHandler handler = (IServerPlayNetworkHandler)player.networkHandler;
+		return handler != null && handler.osl$networking$isPlayReady();
+	}
+
 	public static boolean canSend(ServerPlayerEntity player, String channel) {
-		return ((IServerPlayNetworkHandler)player.networkHandler).osl$networking$isRegisteredClientChannel(channel);
+		IServerPlayNetworkHandler handler = (IServerPlayNetworkHandler)player.networkHandler;
+		return handler != null && handler.osl$networking$isRegisteredClientChannel(channel);
 	}
 
 	public static void send(ServerPlayerEntity player, String channel, IOConsumer<DataOutput> writer) {

--- a/libraries/networking/networking-mc13w41a-mc14w20b/src/main/java/net/ornithemc/osl/networking/api/client/ClientConnectionEvents.java
+++ b/libraries/networking/networking-mc13w41a-mc14w20b/src/main/java/net/ornithemc/osl/networking/api/client/ClientConnectionEvents.java
@@ -10,10 +10,19 @@ public class ClientConnectionEvents {
 
 	/**
 	 * This event is fired after a successful login occurs.
+	 * Note that channel registration happens after login,
+	 * and until then data cannot safely be sent to the server.
 	 * This applies to connections to dedicated servers as
 	 * well as connections to integrated servers.
 	 */
 	public static final Event<Consumer<Minecraft>> LOGIN = Event.consumer();
+	/**
+	 * This event is fired after login, once channel registration is complete.
+	 * This marks the moment data can safely be sent to the server.
+	 * This applies to connections to dedicated servers as
+	 * well as connections to integrated servers.
+	 */
+	public static final Event<Consumer<Minecraft>> PLAY_READY = Event.consumer();
 	/**
 	 * This event is fired when the client disconnects from the server.
 	 * This applies to connections to dedicated servers as

--- a/libraries/networking/networking-mc13w41a-mc14w20b/src/main/java/net/ornithemc/osl/networking/api/client/ClientPlayNetworking.java
+++ b/libraries/networking/networking-mc13w41a-mc14w20b/src/main/java/net/ornithemc/osl/networking/api/client/ClientPlayNetworking.java
@@ -34,6 +34,13 @@ public final class ClientPlayNetworking {
 	}
 
 	/**
+	 * Check whether the connection is ready for data to be sent to the server.
+	 */
+	public static boolean isPlayReady() {
+		return ClientPlayNetworkingImpl.isPlayReady();
+	}
+
+	/**
 	 * Check whether the given channel is open for data to be sent through it.
 	 * This method will return {@code false} if the client is not connected to a
 	 * server, or if the server has no listeners for the given channel.

--- a/libraries/networking/networking-mc13w41a-mc14w20b/src/main/java/net/ornithemc/osl/networking/api/server/ServerConnectionEvents.java
+++ b/libraries/networking/networking-mc13w41a-mc14w20b/src/main/java/net/ornithemc/osl/networking/api/server/ServerConnectionEvents.java
@@ -11,10 +11,19 @@ public class ServerConnectionEvents {
 
 	/**
 	 * This event is fired after a successful login occurs.
+	 * Note that channel registration happens after login,
+	 * and until then data cannot safely be sent to the client.
 	 * This applies to connections to dedicated servers as
 	 * well as connections to integrated servers.
 	 */
 	public static final Event<BiConsumer<MinecraftServer, ServerPlayerEntity>> LOGIN = Event.biConsumer();
+	/**
+	 * This event is fired after login, once channel registration is complete.
+	 * This marks the moment data can safely be sent to the client.
+	 * This applies to connections to dedicated servers as
+	 * well as connections to integrated servers.
+	 */
+	public static final Event<BiConsumer<MinecraftServer, ServerPlayerEntity>> PLAY_READY = Event.biConsumer();
 	/**
 	 * This event is fired when a client disconnects from the server.
 	 * This applies to connections to dedicated servers as

--- a/libraries/networking/networking-mc13w41a-mc14w20b/src/main/java/net/ornithemc/osl/networking/api/server/ServerPlayNetworking.java
+++ b/libraries/networking/networking-mc13w41a-mc14w20b/src/main/java/net/ornithemc/osl/networking/api/server/ServerPlayNetworking.java
@@ -35,6 +35,13 @@ public final class ServerPlayNetworking {
 	}
 
 	/**
+	 * Check whether the connection is ready for data to be sent to the client.
+	 */
+	public static boolean isPlayReady(ServerPlayerEntity player) {
+		return ServerPlayNetworkingImpl.isPlayReady(player);
+	}
+
+	/**
 	 * Check whether the given channel is open for data to be sent through it.
 	 * This method will return {@code false} if the client has no listeners for
 	 * the given channel.

--- a/libraries/networking/networking-mc13w41a-mc14w20b/src/main/java/net/ornithemc/osl/networking/impl/Networking.java
+++ b/libraries/networking/networking-mc13w41a-mc14w20b/src/main/java/net/ornithemc/osl/networking/impl/Networking.java
@@ -1,25 +1,24 @@
 package net.ornithemc.osl.networking.impl;
 
-import java.io.DataInput;
-import java.io.DataOutput;
-import java.io.IOException;
 import java.util.LinkedHashSet;
 import java.util.Set;
 
-import net.minecraft.network.packet.Packet;
+import net.minecraft.network.PacketByteBuf;
 
 import net.ornithemc.osl.entrypoints.api.ModInitializer;
 import net.ornithemc.osl.entrypoints.api.client.ClientModInitializer;
 import net.ornithemc.osl.lifecycle.api.client.MinecraftClientEvents;
 import net.ornithemc.osl.lifecycle.api.server.MinecraftServerEvents;
+import net.ornithemc.osl.networking.api.client.ClientConnectionEvents;
 import net.ornithemc.osl.networking.api.client.ClientPlayNetworking;
+import net.ornithemc.osl.networking.api.server.ServerConnectionEvents;
 import net.ornithemc.osl.networking.api.server.ServerPlayNetworking;
 import net.ornithemc.osl.networking.impl.client.ClientPlayNetworkingImpl;
-import net.ornithemc.osl.networking.impl.interfaces.mixin.IClientNetworkHandler;
+import net.ornithemc.osl.networking.impl.interfaces.mixin.IClientPlayNetworkHandler;
 import net.ornithemc.osl.networking.impl.interfaces.mixin.IServerPlayNetworkHandler;
 import net.ornithemc.osl.networking.impl.server.ServerPlayNetworkingImpl;
 
-public class NetworkingInitializer implements ModInitializer, ClientModInitializer {
+public class Networking implements ModInitializer, ClientModInitializer {
 
 	@Override
 	public void init() {
@@ -30,11 +29,8 @@ public class NetworkingInitializer implements ModInitializer, ClientModInitializ
 			ServerPlayNetworkingImpl.destroy(server);
 		});
 		ServerPlayNetworking.registerListener(CommonChannels.CHANNELS, (server, handler, player, data) -> {
-			Set<String> channels = readChannels(data);
-
-			if (!channels.isEmpty()) {
-				((IServerPlayNetworkHandler)handler).osl$networking$registerClientChannels(channels);
-			}
+			((IServerPlayNetworkHandler)handler).osl$networking$registerClientChannels(readChannels(data));
+			ServerConnectionEvents.PLAY_READY.invoker().accept(server, player);
 
 			return true;
 		});
@@ -49,34 +45,31 @@ public class NetworkingInitializer implements ModInitializer, ClientModInitializ
 			ClientPlayNetworkingImpl.destroy(minecraft);
 		});
 		ClientPlayNetworking.registerListener(CommonChannels.CHANNELS, (minecraft, handler, data) -> {
-			Set<String> channels = readChannels(data);
-
-			if (!channels.isEmpty()) {
-				((IClientNetworkHandler)handler).osl$networking$registerServerChannels(channels);
-			}
+			((IClientPlayNetworkHandler)handler).osl$networking$registerServerChannels(readChannels(data));
+			ClientConnectionEvents.PLAY_READY.invoker().accept(minecraft);
 
 			return true;
 		});
 	}
 
-	public static Set<String> readChannels(DataInput data) throws IOException {
+	public static Set<String> readChannels(PacketByteBuf data) {
 		Set<String> channels = new LinkedHashSet<>();
 		int channelCount = data.readInt();
 
 		if (channelCount > 0) {
 			for (int i = 0; i < channelCount; i++) {
-				channels.add(Packet.readString(data, 20));
+				channels.add(data.readString(20));
 			}
 		}
 
 		return channels;
 	}
 
-	public static void writeChannels(DataOutput data, Set<String> channels) throws IOException {
+	public static void writeChannels(PacketByteBuf data, Set<String> channels) {
 		data.writeInt(channels.size());
 
 		for (String channel : channels) {
-			Packet.writeString(channel, data);
+			data.writeString(channel);
 		}
 	}
 }

--- a/libraries/networking/networking-mc13w41a-mc14w20b/src/main/java/net/ornithemc/osl/networking/impl/Networking.java
+++ b/libraries/networking/networking-mc13w41a-mc14w20b/src/main/java/net/ornithemc/osl/networking/impl/Networking.java
@@ -29,6 +29,11 @@ public class Networking implements ModInitializer, ClientModInitializer {
 			ServerPlayNetworkingImpl.destroy(server);
 		});
 		ServerPlayNetworking.registerListener(CommonChannels.CHANNELS, (server, handler, player, data) -> {
+			// send channel registration data as a response to receiving client channel registration data
+			ServerPlayNetworkingImpl.doSend(player, CommonChannels.CHANNELS, response -> {
+				Networking.writeChannels(response, ServerPlayNetworkingImpl.LISTENERS.keySet());
+			});
+
 			((IServerPlayNetworkHandler)handler).osl$networking$registerClientChannels(readChannels(data));
 			ServerConnectionEvents.PLAY_READY.invoker().accept(server, player);
 

--- a/libraries/networking/networking-mc13w41a-mc14w20b/src/main/java/net/ornithemc/osl/networking/impl/client/ClientPlayNetworkingImpl.java
+++ b/libraries/networking/networking-mc13w41a-mc14w20b/src/main/java/net/ornithemc/osl/networking/impl/client/ClientPlayNetworkingImpl.java
@@ -81,6 +81,11 @@ public final class ClientPlayNetworkingImpl {
 		return false;
 	}
 
+	public static boolean isPlayReady() {
+		IClientPlayNetworkHandler handler = (IClientPlayNetworkHandler)minecraft.getNetworkHandler();
+		return handler != null && handler.osl$networking$isPlayReady();
+	}
+
 	public static boolean canSend(String channel) {
 		IClientPlayNetworkHandler handler = (IClientPlayNetworkHandler)minecraft.getNetworkHandler();
 		return handler != null && handler.osl$networking$isRegisteredServerChannel(channel);

--- a/libraries/networking/networking-mc13w41a-mc14w20b/src/main/java/net/ornithemc/osl/networking/impl/interfaces/mixin/IClientPlayNetworkHandler.java
+++ b/libraries/networking/networking-mc13w41a-mc14w20b/src/main/java/net/ornithemc/osl/networking/impl/interfaces/mixin/IClientPlayNetworkHandler.java
@@ -4,6 +4,8 @@ import java.util.Set;
 
 public interface IClientPlayNetworkHandler {
 
+	boolean osl$networking$isPlayReady();
+
 	void osl$networking$registerServerChannels(Set<String> channels);
 
 	boolean osl$networking$isRegisteredServerChannel(String channel);

--- a/libraries/networking/networking-mc13w41a-mc14w20b/src/main/java/net/ornithemc/osl/networking/impl/interfaces/mixin/IServerPlayNetworkHandler.java
+++ b/libraries/networking/networking-mc13w41a-mc14w20b/src/main/java/net/ornithemc/osl/networking/impl/interfaces/mixin/IServerPlayNetworkHandler.java
@@ -4,6 +4,8 @@ import java.util.Set;
 
 public interface IServerPlayNetworkHandler {
 
+	boolean osl$networking$isPlayReady();
+
 	void osl$networking$registerClientChannels(Set<String> channels);
 
 	boolean osl$networking$isRegisteredClientChannel(String channel);

--- a/libraries/networking/networking-mc13w41a-mc14w20b/src/main/java/net/ornithemc/osl/networking/impl/mixin/client/ClientPlayNetworkHandlerMixin.java
+++ b/libraries/networking/networking-mc13w41a-mc14w20b/src/main/java/net/ornithemc/osl/networking/impl/mixin/client/ClientPlayNetworkHandlerMixin.java
@@ -17,7 +17,7 @@ import net.minecraft.network.packet.s2c.play.CustomPayloadS2CPacket;
 
 import net.ornithemc.osl.networking.api.client.ClientConnectionEvents;
 import net.ornithemc.osl.networking.impl.CommonChannels;
-import net.ornithemc.osl.networking.impl.NetworkingInitializer;
+import net.ornithemc.osl.networking.impl.Networking;
 import net.ornithemc.osl.networking.impl.client.ClientPlayNetworkingImpl;
 import net.ornithemc.osl.networking.impl.interfaces.mixin.IClientPlayNetworkHandler;
 
@@ -29,7 +29,20 @@ public class ClientPlayNetworkHandlerMixin implements IClientPlayNetworkHandler 
 	/**
 	 * Channels that the server is listening to.
 	 */
-	@Unique private final Set<String> serverChannels = new LinkedHashSet<>();
+	@Unique private Set<String> serverChannels;
+
+	@Inject(
+		method = "handleLogin",
+		at = @At(
+			value = "HEAD"
+		)
+	)
+	private void osl$networking$registerChannels(CallbackInfo ci) {
+		// send channel registration data as soon as login occurs
+		ClientPlayNetworkingImpl.doSend(CommonChannels.CHANNELS, data -> {
+			Networking.writeChannels(data, ClientPlayNetworkingImpl.LISTENERS.keySet());
+		});
+	}
 
 	@Inject(
 		method = "handleLogin",
@@ -38,10 +51,6 @@ public class ClientPlayNetworkHandlerMixin implements IClientPlayNetworkHandler 
 		)
 	)
 	private void osl$networking$handleLogin(CallbackInfo ci) {
-		ClientPlayNetworkingImpl.doSend(CommonChannels.CHANNELS, data -> {
-			NetworkingInitializer.writeChannels(data, ClientPlayNetworkingImpl.LISTENERS.keySet());
-		});
-
 		ClientConnectionEvents.LOGIN.invoker().accept(minecraft);
 	}
 
@@ -53,7 +62,7 @@ public class ClientPlayNetworkHandlerMixin implements IClientPlayNetworkHandler 
 	)
 	private void osl$networking$handleDisconnect(CallbackInfo ci) {
 		ClientConnectionEvents.DISCONNECT.invoker().accept(minecraft);
-		serverChannels.clear();
+		serverChannels = null;
 	}
 
 	@Inject(
@@ -70,8 +79,13 @@ public class ClientPlayNetworkHandlerMixin implements IClientPlayNetworkHandler 
 	}
 
 	@Override
+	public boolean osl$networking$isPlayReady() {
+		return serverChannels != null;
+	}
+
+	@Override
 	public void osl$networking$registerServerChannels(Set<String> channels) {
-		serverChannels.addAll(channels);
+		serverChannels = new LinkedHashSet<>(channels);
 	}
 
 	@Override

--- a/libraries/networking/networking-mc13w41a-mc14w20b/src/main/java/net/ornithemc/osl/networking/impl/mixin/client/ClientPlayNetworkHandlerMixin.java
+++ b/libraries/networking/networking-mc13w41a-mc14w20b/src/main/java/net/ornithemc/osl/networking/impl/mixin/client/ClientPlayNetworkHandlerMixin.java
@@ -34,23 +34,15 @@ public class ClientPlayNetworkHandlerMixin implements IClientPlayNetworkHandler 
 	@Inject(
 		method = "handleLogin",
 		at = @At(
-			value = "HEAD"
-		)
-	)
-	private void osl$networking$registerChannels(CallbackInfo ci) {
-		// send channel registration data as soon as login occurs
-		ClientPlayNetworkingImpl.doSend(CommonChannels.CHANNELS, data -> {
-			Networking.writeChannels(data, ClientPlayNetworkingImpl.LISTENERS.keySet());
-		});
-	}
-
-	@Inject(
-		method = "handleLogin",
-		at = @At(
 			value = "TAIL"
 		)
 	)
 	private void osl$networking$handleLogin(CallbackInfo ci) {
+		// send channel registration data as soon as login occurs
+		ClientPlayNetworkingImpl.doSend(CommonChannels.CHANNELS, data -> {
+			Networking.writeChannels(data, ClientPlayNetworkingImpl.LISTENERS.keySet());
+		});
+
 		ClientConnectionEvents.LOGIN.invoker().accept(minecraft);
 	}
 

--- a/libraries/networking/networking-mc13w41a-mc14w20b/src/main/java/net/ornithemc/osl/networking/impl/mixin/client/ClientPlayNetworkHandlerMixin.java
+++ b/libraries/networking/networking-mc13w41a-mc14w20b/src/main/java/net/ornithemc/osl/networking/impl/mixin/client/ClientPlayNetworkHandlerMixin.java
@@ -82,6 +82,6 @@ public class ClientPlayNetworkHandlerMixin implements IClientPlayNetworkHandler 
 
 	@Override
 	public boolean osl$networking$isRegisteredServerChannel(String channel) {
-		return serverChannels.contains(channel);
+		return serverChannels != null && serverChannels.contains(channel);
 	}
 }

--- a/libraries/networking/networking-mc13w41a-mc14w20b/src/main/java/net/ornithemc/osl/networking/impl/mixin/client/CustomPayloadS2CPacketMixin.java
+++ b/libraries/networking/networking-mc13w41a-mc14w20b/src/main/java/net/ornithemc/osl/networking/impl/mixin/client/CustomPayloadS2CPacketMixin.java
@@ -1,4 +1,4 @@
-package net.ornithemc.osl.networking.impl.mixin.common;
+package net.ornithemc.osl.networking.impl.mixin.client;
 
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;

--- a/libraries/networking/networking-mc13w41a-mc14w20b/src/main/java/net/ornithemc/osl/networking/impl/mixin/common/PlayerManagerMixin.java
+++ b/libraries/networking/networking-mc13w41a-mc14w20b/src/main/java/net/ornithemc/osl/networking/impl/mixin/common/PlayerManagerMixin.java
@@ -14,7 +14,7 @@ import net.minecraft.server.entity.living.player.ServerPlayerEntity;
 
 import net.ornithemc.osl.networking.api.server.ServerConnectionEvents;
 import net.ornithemc.osl.networking.impl.CommonChannels;
-import net.ornithemc.osl.networking.impl.NetworkingInitializer;
+import net.ornithemc.osl.networking.impl.Networking;
 import net.ornithemc.osl.networking.impl.server.ServerPlayNetworkingImpl;
 
 @Mixin(PlayerManager.class)
@@ -30,8 +30,9 @@ public class PlayerManagerMixin {
 		)
 	)
 	private void osl$networking$registerChannels(Connection connection, ServerPlayerEntity player, CallbackInfo ci) {
+		// send channel registration data as soon as login occurs
 		ServerPlayNetworkingImpl.doSend(player, CommonChannels.CHANNELS, data -> {
-			NetworkingInitializer.writeChannels(data, ServerPlayNetworkingImpl.LISTENERS.keySet());
+			Networking.writeChannels(data, ServerPlayNetworkingImpl.LISTENERS.keySet());
 		});
 	}
 

--- a/libraries/networking/networking-mc13w41a-mc14w20b/src/main/java/net/ornithemc/osl/networking/impl/mixin/common/PlayerManagerMixin.java
+++ b/libraries/networking/networking-mc13w41a-mc14w20b/src/main/java/net/ornithemc/osl/networking/impl/mixin/common/PlayerManagerMixin.java
@@ -13,28 +13,11 @@ import net.minecraft.server.PlayerManager;
 import net.minecraft.server.entity.living.player.ServerPlayerEntity;
 
 import net.ornithemc.osl.networking.api.server.ServerConnectionEvents;
-import net.ornithemc.osl.networking.impl.CommonChannels;
-import net.ornithemc.osl.networking.impl.Networking;
-import net.ornithemc.osl.networking.impl.server.ServerPlayNetworkingImpl;
 
 @Mixin(PlayerManager.class)
 public class PlayerManagerMixin {
 
 	@Shadow @Final private MinecraftServer server;
-
-	@Inject(
-		method = "onLogin",
-		at = @At(
-			value = "NEW",
-			target = "Lnet/minecraft/network/packet/s2c/play/LoginS2CPacket;"
-		)
-	)
-	private void osl$networking$registerChannels(Connection connection, ServerPlayerEntity player, CallbackInfo ci) {
-		// send channel registration data as soon as login occurs
-		ServerPlayNetworkingImpl.doSend(player, CommonChannels.CHANNELS, data -> {
-			Networking.writeChannels(data, ServerPlayNetworkingImpl.LISTENERS.keySet());
-		});
-	}
 
 	@Inject(
 		method = "onLogin",

--- a/libraries/networking/networking-mc13w41a-mc14w20b/src/main/java/net/ornithemc/osl/networking/impl/mixin/common/ServerPlayNetworkHandlerMixin.java
+++ b/libraries/networking/networking-mc13w41a-mc14w20b/src/main/java/net/ornithemc/osl/networking/impl/mixin/common/ServerPlayNetworkHandlerMixin.java
@@ -67,6 +67,6 @@ public class ServerPlayNetworkHandlerMixin implements IServerPlayNetworkHandler 
 
 	@Override
 	public boolean osl$networking$isRegisteredClientChannel(String channel) {
-		return clientChannels.contains(channel);
+		return clientChannels != null && clientChannels.contains(channel);
 	}
 }

--- a/libraries/networking/networking-mc13w41a-mc14w20b/src/main/java/net/ornithemc/osl/networking/impl/mixin/common/ServerPlayNetworkHandlerMixin.java
+++ b/libraries/networking/networking-mc13w41a-mc14w20b/src/main/java/net/ornithemc/osl/networking/impl/mixin/common/ServerPlayNetworkHandlerMixin.java
@@ -29,7 +29,7 @@ public class ServerPlayNetworkHandlerMixin implements IServerPlayNetworkHandler 
 	/**
 	 * Channels that the client is listening to.
 	 */
-	@Unique private final Set<String> clientChannels = new LinkedHashSet<>();
+	@Unique private Set<String> clientChannels;
 
 	@Inject(
 		method = "onDisconnect",
@@ -39,7 +39,7 @@ public class ServerPlayNetworkHandlerMixin implements IServerPlayNetworkHandler 
 	)
 	private void osl$networking$handleDisconnect(CallbackInfo ci) {
 		ServerConnectionEvents.DISCONNECT.invoker().accept(server, player);
-		clientChannels.clear();
+		clientChannels = null;
 	}
 
 	@Inject(
@@ -56,8 +56,13 @@ public class ServerPlayNetworkHandlerMixin implements IServerPlayNetworkHandler 
 	}
 
 	@Override
+	public boolean osl$networking$isPlayReady() {
+		return clientChannels != null;
+	}
+
+	@Override
 	public void osl$networking$registerClientChannels(Set<String> channels) {
-		clientChannels.addAll(channels);
+		clientChannels = new LinkedHashSet<>(channels);
 	}
 
 	@Override

--- a/libraries/networking/networking-mc13w41a-mc14w20b/src/main/java/net/ornithemc/osl/networking/impl/server/ServerPlayNetworkingImpl.java
+++ b/libraries/networking/networking-mc13w41a-mc14w20b/src/main/java/net/ornithemc/osl/networking/impl/server/ServerPlayNetworkingImpl.java
@@ -85,8 +85,14 @@ public final class ServerPlayNetworkingImpl {
 		return false;
 	}
 
+	public static boolean isPlayReady(ServerPlayerEntity player) {
+		IServerPlayNetworkHandler handler = (IServerPlayNetworkHandler)player.networkHandler;
+		return handler != null && handler.osl$networking$isPlayReady();
+	}
+
 	public static boolean canSend(ServerPlayerEntity player, String channel) {
-		return ((IServerPlayNetworkHandler)player.networkHandler).osl$networking$isRegisteredClientChannel(channel);
+		IServerPlayNetworkHandler handler = (IServerPlayNetworkHandler)player.networkHandler;
+		return handler != null && handler.osl$networking$isRegisteredClientChannel(channel);
 	}
 
 	public static void send(ServerPlayerEntity player, String channel, Consumer<PacketByteBuf> writer) {

--- a/libraries/networking/networking-mc13w41a-mc14w20b/src/main/resources/osl.networking.mixins.json
+++ b/libraries/networking/networking-mc13w41a-mc14w20b/src/main/resources/osl.networking.mixins.json
@@ -5,12 +5,12 @@
 	"compatibilityLevel": "JAVA_8",
 	"mixins": [
 		"common.CustomPayloadC2SPacketMixin",
-		"common.CustomPayloadS2CPacketMixin",
 		"common.PlayerManagerMixin",
 		"common.ServerPlayNetworkHandlerMixin"
 	],
 	"client": [
-		"client.ClientPlayNetworkHandlerMixin"
+		"client.ClientPlayNetworkHandlerMixin",
+		"client.CustomPayloadS2CPacketMixin"
 	],
 	"server": [
 	],

--- a/libraries/networking/networking-mc14w21a-mc14w30c/src/main/java/net/ornithemc/osl/networking/api/client/ClientConnectionEvents.java
+++ b/libraries/networking/networking-mc14w21a-mc14w30c/src/main/java/net/ornithemc/osl/networking/api/client/ClientConnectionEvents.java
@@ -10,10 +10,19 @@ public class ClientConnectionEvents {
 
 	/**
 	 * This event is fired after a successful login occurs.
+	 * Note that channel registration happens after login,
+	 * and until then data cannot safely be sent to the server.
 	 * This applies to connections to dedicated servers as
 	 * well as connections to integrated servers.
 	 */
 	public static final Event<Consumer<Minecraft>> LOGIN = Event.consumer();
+	/**
+	 * This event is fired after login, once channel registration is complete.
+	 * This marks the moment data can safely be sent to the server.
+	 * This applies to connections to dedicated servers as
+	 * well as connections to integrated servers.
+	 */
+	public static final Event<Consumer<Minecraft>> PLAY_READY = Event.consumer();
 	/**
 	 * This event is fired when the client disconnects from the server.
 	 * This applies to connections to dedicated servers as

--- a/libraries/networking/networking-mc14w21a-mc14w30c/src/main/java/net/ornithemc/osl/networking/api/client/ClientPlayNetworking.java
+++ b/libraries/networking/networking-mc14w21a-mc14w30c/src/main/java/net/ornithemc/osl/networking/api/client/ClientPlayNetworking.java
@@ -50,6 +50,13 @@ public final class ClientPlayNetworking {
 	}
 
 	/**
+	 * Check whether the connection is ready for data to be sent to the server.
+	 */
+	public static boolean isPlayReady() {
+		return ClientPlayNetworkingImpl.isPlayReady();
+	}
+
+	/**
 	 * Check whether the given channel is open for data to be sent through it.
 	 * This method will return {@code false} if the client is not connected to a
 	 * server, or if the server has no listeners for the given channel.

--- a/libraries/networking/networking-mc14w21a-mc14w30c/src/main/java/net/ornithemc/osl/networking/api/server/ServerConnectionEvents.java
+++ b/libraries/networking/networking-mc14w21a-mc14w30c/src/main/java/net/ornithemc/osl/networking/api/server/ServerConnectionEvents.java
@@ -11,10 +11,19 @@ public class ServerConnectionEvents {
 
 	/**
 	 * This event is fired after a successful login occurs.
+	 * Note that channel registration happens after login,
+	 * and until then data cannot safely be sent to the client.
 	 * This applies to connections to dedicated servers as
 	 * well as connections to integrated servers.
 	 */
 	public static final Event<BiConsumer<MinecraftServer, ServerPlayerEntity>> LOGIN = Event.biConsumer();
+	/**
+	 * This event is fired after login, once channel registration is complete.
+	 * This marks the moment data can safely be sent to the client.
+	 * This applies to connections to dedicated servers as
+	 * well as connections to integrated servers.
+	 */
+	public static final Event<BiConsumer<MinecraftServer, ServerPlayerEntity>> PLAY_READY = Event.biConsumer();
 	/**
 	 * This event is fired when a client disconnects from the server.
 	 * This applies to connections to dedicated servers as

--- a/libraries/networking/networking-mc14w21a-mc14w30c/src/main/java/net/ornithemc/osl/networking/api/server/ServerPlayNetworking.java
+++ b/libraries/networking/networking-mc14w21a-mc14w30c/src/main/java/net/ornithemc/osl/networking/api/server/ServerPlayNetworking.java
@@ -51,6 +51,13 @@ public final class ServerPlayNetworking {
 	}
 
 	/**
+	 * Check whether the connection is ready for data to be sent to the client.
+	 */
+	public static boolean isPlayReady(ServerPlayerEntity player) {
+		return ServerPlayNetworkingImpl.isPlayReady(player);
+	}
+
+	/**
 	 * Check whether the given channel is open for data to be sent through it.
 	 * This method will return {@code false} if the client has no listeners for
 	 * the given channel.

--- a/libraries/networking/networking-mc14w21a-mc14w30c/src/main/java/net/ornithemc/osl/networking/impl/Networking.java
+++ b/libraries/networking/networking-mc14w21a-mc14w30c/src/main/java/net/ornithemc/osl/networking/impl/Networking.java
@@ -4,20 +4,21 @@ import java.util.LinkedHashSet;
 import java.util.Set;
 
 import net.minecraft.network.PacketByteBuf;
-import net.minecraft.resource.Identifier;
 
 import net.ornithemc.osl.entrypoints.api.ModInitializer;
 import net.ornithemc.osl.entrypoints.api.client.ClientModInitializer;
 import net.ornithemc.osl.lifecycle.api.client.MinecraftClientEvents;
 import net.ornithemc.osl.lifecycle.api.server.MinecraftServerEvents;
+import net.ornithemc.osl.networking.api.client.ClientConnectionEvents;
 import net.ornithemc.osl.networking.api.client.ClientPlayNetworking;
+import net.ornithemc.osl.networking.api.server.ServerConnectionEvents;
 import net.ornithemc.osl.networking.api.server.ServerPlayNetworking;
 import net.ornithemc.osl.networking.impl.client.ClientPlayNetworkingImpl;
 import net.ornithemc.osl.networking.impl.interfaces.mixin.IClientPlayNetworkHandler;
 import net.ornithemc.osl.networking.impl.interfaces.mixin.IServerPlayNetworkHandler;
 import net.ornithemc.osl.networking.impl.server.ServerPlayNetworkingImpl;
 
-public class NetworkingInitializer implements ModInitializer, ClientModInitializer {
+public class Networking implements ModInitializer, ClientModInitializer {
 
 	@Override
 	public void init() {
@@ -28,11 +29,8 @@ public class NetworkingInitializer implements ModInitializer, ClientModInitializ
 			ServerPlayNetworkingImpl.destroy(server);
 		});
 		ServerPlayNetworking.registerListener(CommonChannels.CHANNELS, (server, handler, player, data) -> {
-			Set<Identifier> channels = readChannels(data);
-
-			if (!channels.isEmpty()) {
-				((IServerPlayNetworkHandler)handler).osl$networking$registerClientChannels(channels);
-			}
+			((IServerPlayNetworkHandler)handler).osl$networking$registerClientChannels(readChannels(data));
+			ServerConnectionEvents.PLAY_READY.invoker().accept(server, player);
 
 			return true;
 		});
@@ -47,34 +45,31 @@ public class NetworkingInitializer implements ModInitializer, ClientModInitializ
 			ClientPlayNetworkingImpl.destroy(minecraft);
 		});
 		ClientPlayNetworking.registerListener(CommonChannels.CHANNELS, (minecraft, handler, data) -> {
-			Set<Identifier> channels = readChannels(data);
-
-			if (!channels.isEmpty()) {
-				((IClientPlayNetworkHandler)handler).osl$networking$registerServerChannels(channels);
-			}
+			((IClientPlayNetworkHandler)handler).osl$networking$registerServerChannels(readChannels(data));
+			ClientConnectionEvents.PLAY_READY.invoker().accept(minecraft);
 
 			return true;
 		});
 	}
 
-	public static Set<Identifier> readChannels(PacketByteBuf data) {
-		Set<Identifier> channels = new LinkedHashSet<>();
+	public static Set<String> readChannels(PacketByteBuf data) {
+		Set<String> channels = new LinkedHashSet<>();
 		int channelCount = data.readInt();
 
 		if (channelCount > 0) {
 			for (int i = 0; i < channelCount; i++) {
-				channels.add(data.readIdentifier());
+				channels.add(data.readString(20));
 			}
 		}
 
 		return channels;
 	}
 
-	public static void writeChannels(PacketByteBuf data, Set<Identifier> channels) {
+	public static void writeChannels(PacketByteBuf data, Set<String> channels) {
 		data.writeInt(channels.size());
 
-		for (Identifier channel : channels) {
-			data.writeIdentifier(channel);
+		for (String channel : channels) {
+			data.writeString(channel);
 		}
 	}
 }

--- a/libraries/networking/networking-mc14w21a-mc14w30c/src/main/java/net/ornithemc/osl/networking/impl/Networking.java
+++ b/libraries/networking/networking-mc14w21a-mc14w30c/src/main/java/net/ornithemc/osl/networking/impl/Networking.java
@@ -29,6 +29,11 @@ public class Networking implements ModInitializer, ClientModInitializer {
 			ServerPlayNetworkingImpl.destroy(server);
 		});
 		ServerPlayNetworking.registerListener(CommonChannels.CHANNELS, (server, handler, player, data) -> {
+			// send channel registration data as a response to receiving client channel registration data
+			ServerPlayNetworkingImpl.doSend(player, CommonChannels.CHANNELS, response -> {
+				Networking.writeChannels(response, ServerPlayNetworkingImpl.LISTENERS.keySet());
+			});
+
 			((IServerPlayNetworkHandler)handler).osl$networking$registerClientChannels(readChannels(data));
 			ServerConnectionEvents.PLAY_READY.invoker().accept(server, player);
 

--- a/libraries/networking/networking-mc14w21a-mc14w30c/src/main/java/net/ornithemc/osl/networking/impl/client/ClientPlayNetworkingImpl.java
+++ b/libraries/networking/networking-mc14w21a-mc14w30c/src/main/java/net/ornithemc/osl/networking/impl/client/ClientPlayNetworkingImpl.java
@@ -91,6 +91,11 @@ public final class ClientPlayNetworkingImpl {
 		return false;
 	}
 
+	public static boolean isPlayReady() {
+		IClientPlayNetworkHandler handler = (IClientPlayNetworkHandler)minecraft.getNetworkHandler();
+		return handler != null && handler.osl$networking$isPlayReady();
+	}
+
 	public static boolean canSend(String channel) {
 		IClientPlayNetworkHandler handler = (IClientPlayNetworkHandler)minecraft.getNetworkHandler();
 		return handler != null && handler.osl$networking$isRegisteredServerChannel(channel);

--- a/libraries/networking/networking-mc14w21a-mc14w30c/src/main/java/net/ornithemc/osl/networking/impl/interfaces/mixin/IClientPlayNetworkHandler.java
+++ b/libraries/networking/networking-mc14w21a-mc14w30c/src/main/java/net/ornithemc/osl/networking/impl/interfaces/mixin/IClientPlayNetworkHandler.java
@@ -4,6 +4,8 @@ import java.util.Set;
 
 public interface IClientPlayNetworkHandler {
 
+	boolean osl$networking$isPlayReady();
+
 	void osl$networking$registerServerChannels(Set<String> channels);
 
 	boolean osl$networking$isRegisteredServerChannel(String channel);

--- a/libraries/networking/networking-mc14w21a-mc14w30c/src/main/java/net/ornithemc/osl/networking/impl/interfaces/mixin/IServerPlayNetworkHandler.java
+++ b/libraries/networking/networking-mc14w21a-mc14w30c/src/main/java/net/ornithemc/osl/networking/impl/interfaces/mixin/IServerPlayNetworkHandler.java
@@ -4,6 +4,8 @@ import java.util.Set;
 
 public interface IServerPlayNetworkHandler {
 
+	boolean osl$networking$isPlayReady();
+
 	void osl$networking$registerClientChannels(Set<String> channels);
 
 	boolean osl$networking$isRegisteredClientChannel(String channel);

--- a/libraries/networking/networking-mc14w21a-mc14w30c/src/main/java/net/ornithemc/osl/networking/impl/mixin/client/ClientPlayNetworkHandlerMixin.java
+++ b/libraries/networking/networking-mc14w21a-mc14w30c/src/main/java/net/ornithemc/osl/networking/impl/mixin/client/ClientPlayNetworkHandlerMixin.java
@@ -9,7 +9,6 @@ import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.At.Shift;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 import net.minecraft.client.Minecraft;
@@ -35,25 +34,15 @@ public class ClientPlayNetworkHandlerMixin implements IClientPlayNetworkHandler 
 	@Inject(
 		method = "handleLogin",
 		at = @At(
-			value = "INVOKE",
-			shift = Shift.AFTER,
-			target = "Lnet/minecraft/network/PacketUtils;ensureOnSameThread(Lnet/minecraft/network/packet/Packet;Lnet/minecraft/network/handler/PacketHandler;Lnet/minecraft/util/BlockableEventLoop;)V"
-		)
-	)
-	private void osl$networking$registerChannels(CallbackInfo ci) {
-		// send channel registration data as soon as login occurs
-		ClientPlayNetworkingImpl.doSend(CommonChannels.CHANNELS, data -> {
-			Networking.writeChannels(data, ClientPlayNetworkingImpl.LISTENERS.keySet());
-		});
-	}
-
-	@Inject(
-		method = "handleLogin",
-		at = @At(
 			value = "TAIL"
 		)
 	)
 	private void osl$networking$handleLogin(CallbackInfo ci) {
+		// send channel registration data as soon as login occurs
+		ClientPlayNetworkingImpl.doSend(CommonChannels.CHANNELS, data -> {
+			Networking.writeChannels(data, ClientPlayNetworkingImpl.LISTENERS.keySet());
+		});
+
 		ClientConnectionEvents.LOGIN.invoker().accept(minecraft);
 	}
 

--- a/libraries/networking/networking-mc14w21a-mc14w30c/src/main/java/net/ornithemc/osl/networking/impl/mixin/client/ClientPlayNetworkHandlerMixin.java
+++ b/libraries/networking/networking-mc14w21a-mc14w30c/src/main/java/net/ornithemc/osl/networking/impl/mixin/client/ClientPlayNetworkHandlerMixin.java
@@ -82,6 +82,6 @@ public class ClientPlayNetworkHandlerMixin implements IClientPlayNetworkHandler 
 
 	@Override
 	public boolean osl$networking$isRegisteredServerChannel(String channel) {
-		return serverChannels.contains(channel);
+		return serverChannels != null && serverChannels.contains(channel);
 	}
 }

--- a/libraries/networking/networking-mc14w21a-mc14w30c/src/main/java/net/ornithemc/osl/networking/impl/mixin/common/PlayerManagerMixin.java
+++ b/libraries/networking/networking-mc14w21a-mc14w30c/src/main/java/net/ornithemc/osl/networking/impl/mixin/common/PlayerManagerMixin.java
@@ -14,7 +14,7 @@ import net.minecraft.server.entity.living.player.ServerPlayerEntity;
 
 import net.ornithemc.osl.networking.api.server.ServerConnectionEvents;
 import net.ornithemc.osl.networking.impl.CommonChannels;
-import net.ornithemc.osl.networking.impl.NetworkingInitializer;
+import net.ornithemc.osl.networking.impl.Networking;
 import net.ornithemc.osl.networking.impl.server.ServerPlayNetworkingImpl;
 
 @Mixin(PlayerManager.class)
@@ -30,8 +30,9 @@ public class PlayerManagerMixin {
 		)
 	)
 	private void osl$networking$registerChannels(Connection connection, ServerPlayerEntity player, CallbackInfo ci) {
+		// send channel registration data as soon as login occurs
 		ServerPlayNetworkingImpl.doSend(player, CommonChannels.CHANNELS, data -> {
-			NetworkingInitializer.writeChannels(data, ServerPlayNetworkingImpl.LISTENERS.keySet());
+			Networking.writeChannels(data, ServerPlayNetworkingImpl.LISTENERS.keySet());
 		});
 	}
 

--- a/libraries/networking/networking-mc14w21a-mc14w30c/src/main/java/net/ornithemc/osl/networking/impl/mixin/common/PlayerManagerMixin.java
+++ b/libraries/networking/networking-mc14w21a-mc14w30c/src/main/java/net/ornithemc/osl/networking/impl/mixin/common/PlayerManagerMixin.java
@@ -13,28 +13,11 @@ import net.minecraft.server.PlayerManager;
 import net.minecraft.server.entity.living.player.ServerPlayerEntity;
 
 import net.ornithemc.osl.networking.api.server.ServerConnectionEvents;
-import net.ornithemc.osl.networking.impl.CommonChannels;
-import net.ornithemc.osl.networking.impl.Networking;
-import net.ornithemc.osl.networking.impl.server.ServerPlayNetworkingImpl;
 
 @Mixin(PlayerManager.class)
 public class PlayerManagerMixin {
 
 	@Shadow @Final private MinecraftServer server;
-
-	@Inject(
-		method = "onLogin",
-		at = @At(
-			value = "NEW",
-			target = "Lnet/minecraft/network/packet/s2c/play/LoginS2CPacket;"
-		)
-	)
-	private void osl$networking$registerChannels(Connection connection, ServerPlayerEntity player, CallbackInfo ci) {
-		// send channel registration data as soon as login occurs
-		ServerPlayNetworkingImpl.doSend(player, CommonChannels.CHANNELS, data -> {
-			Networking.writeChannels(data, ServerPlayNetworkingImpl.LISTENERS.keySet());
-		});
-	}
 
 	@Inject(
 		method = "onLogin",

--- a/libraries/networking/networking-mc14w21a-mc14w30c/src/main/java/net/ornithemc/osl/networking/impl/mixin/common/ServerPlayNetworkHandlerMixin.java
+++ b/libraries/networking/networking-mc14w21a-mc14w30c/src/main/java/net/ornithemc/osl/networking/impl/mixin/common/ServerPlayNetworkHandlerMixin.java
@@ -67,6 +67,6 @@ public class ServerPlayNetworkHandlerMixin implements IServerPlayNetworkHandler 
 
 	@Override
 	public boolean osl$networking$isRegisteredClientChannel(String channel) {
-		return clientChannels.contains(channel);
+		return clientChannels != null && clientChannels.contains(channel);
 	}
 }

--- a/libraries/networking/networking-mc14w21a-mc14w30c/src/main/java/net/ornithemc/osl/networking/impl/mixin/common/ServerPlayNetworkHandlerMixin.java
+++ b/libraries/networking/networking-mc14w21a-mc14w30c/src/main/java/net/ornithemc/osl/networking/impl/mixin/common/ServerPlayNetworkHandlerMixin.java
@@ -29,7 +29,7 @@ public class ServerPlayNetworkHandlerMixin implements IServerPlayNetworkHandler 
 	/**
 	 * Channels that the client is listening to.
 	 */
-	@Unique private final Set<String> clientChannels = new LinkedHashSet<>();
+	@Unique private Set<String> clientChannels;
 
 	@Inject(
 		method = "onDisconnect",
@@ -39,7 +39,7 @@ public class ServerPlayNetworkHandlerMixin implements IServerPlayNetworkHandler 
 	)
 	private void osl$networking$handleDisconnect(CallbackInfo ci) {
 		ServerConnectionEvents.DISCONNECT.invoker().accept(server, player);
-		clientChannels.clear();
+		clientChannels = null;
 	}
 
 	@Inject(
@@ -56,8 +56,13 @@ public class ServerPlayNetworkHandlerMixin implements IServerPlayNetworkHandler 
 	}
 
 	@Override
+	public boolean osl$networking$isPlayReady() {
+		return clientChannels != null;
+	}
+
+	@Override
 	public void osl$networking$registerClientChannels(Set<String> channels) {
-		clientChannels.addAll(channels);
+		clientChannels = new LinkedHashSet<>(channels);
 	}
 
 	@Override

--- a/libraries/networking/networking-mc14w21a-mc14w30c/src/main/java/net/ornithemc/osl/networking/impl/server/ServerPlayNetworkingImpl.java
+++ b/libraries/networking/networking-mc14w21a-mc14w30c/src/main/java/net/ornithemc/osl/networking/impl/server/ServerPlayNetworkingImpl.java
@@ -95,8 +95,14 @@ public final class ServerPlayNetworkingImpl {
 		return false;
 	}
 
+	public static boolean isPlayReady(ServerPlayerEntity player) {
+		IServerPlayNetworkHandler handler = (IServerPlayNetworkHandler)player.networkHandler;
+		return handler != null && handler.osl$networking$isPlayReady();
+	}
+
 	public static boolean canSend(ServerPlayerEntity player, String channel) {
-		return ((IServerPlayNetworkHandler)player.networkHandler).osl$networking$isRegisteredClientChannel(channel);
+		IServerPlayNetworkHandler handler = (IServerPlayNetworkHandler)player.networkHandler;
+		return handler != null && handler.osl$networking$isRegisteredClientChannel(channel);
 	}
 
 	public static void send(ServerPlayerEntity player, String channel, Consumer<PacketByteBuf> writer) {

--- a/libraries/networking/networking-mc14w31a-mc1.13-pre2/src/main/java/net/ornithemc/osl/networking/api/client/ClientConnectionEvents.java
+++ b/libraries/networking/networking-mc14w31a-mc1.13-pre2/src/main/java/net/ornithemc/osl/networking/api/client/ClientConnectionEvents.java
@@ -10,10 +10,19 @@ public class ClientConnectionEvents {
 
 	/**
 	 * This event is fired after a successful login occurs.
-	 * This applies to connections to dedicated servers as
+	 * Note that channel registration happens after login,
+	 * and until then data cannot safely be sent to the server.
+	 * This event applies to connections to dedicated servers as
 	 * well as connections to integrated servers.
 	 */
 	public static final Event<Consumer<Minecraft>> LOGIN = Event.consumer();
+	/**
+	 * This event is fired after login, once channel registration is complete.
+	 * This marks the moment data can safely be sent to the server.
+	 * This applies to connections to dedicated servers as
+	 * well as connections to integrated servers.
+	 */
+	public static final Event<Consumer<Minecraft>> PLAY_READY = Event.consumer();
 	/**
 	 * This event is fired when the client disconnects from the server.
 	 * This applies to connections to dedicated servers as

--- a/libraries/networking/networking-mc14w31a-mc1.13-pre2/src/main/java/net/ornithemc/osl/networking/api/client/ClientConnectionEvents.java
+++ b/libraries/networking/networking-mc14w31a-mc1.13-pre2/src/main/java/net/ornithemc/osl/networking/api/client/ClientConnectionEvents.java
@@ -12,7 +12,7 @@ public class ClientConnectionEvents {
 	 * This event is fired after a successful login occurs.
 	 * Note that channel registration happens after login,
 	 * and until then data cannot safely be sent to the server.
-	 * This event applies to connections to dedicated servers as
+	 * This applies to connections to dedicated servers as
 	 * well as connections to integrated servers.
 	 */
 	public static final Event<Consumer<Minecraft>> LOGIN = Event.consumer();

--- a/libraries/networking/networking-mc14w31a-mc1.13-pre2/src/main/java/net/ornithemc/osl/networking/api/client/ClientPlayNetworking.java
+++ b/libraries/networking/networking-mc14w31a-mc1.13-pre2/src/main/java/net/ornithemc/osl/networking/api/client/ClientPlayNetworking.java
@@ -34,6 +34,13 @@ public final class ClientPlayNetworking {
 	}
 
 	/**
+	 * Check whether the connection is ready for data to be sent to the server.
+	 */
+	public static boolean isPlayReady() {
+		return ClientPlayNetworkingImpl.isPlayReady();
+	}
+
+	/**
 	 * Check whether the given channel is open for data to be sent through it.
 	 * This method will return {@code false} if the client is not connected to a
 	 * server, or if the server has no listeners for the given channel.

--- a/libraries/networking/networking-mc14w31a-mc1.13-pre2/src/main/java/net/ornithemc/osl/networking/api/server/ServerConnectionEvents.java
+++ b/libraries/networking/networking-mc14w31a-mc1.13-pre2/src/main/java/net/ornithemc/osl/networking/api/server/ServerConnectionEvents.java
@@ -11,10 +11,19 @@ public class ServerConnectionEvents {
 
 	/**
 	 * This event is fired after a successful login occurs.
+	 * Note that channel registration happens after login,
+	 * and until then data cannot safely be sent to the client.
 	 * This applies to connections to dedicated servers as
 	 * well as connections to integrated servers.
 	 */
 	public static final Event<BiConsumer<MinecraftServer, ServerPlayerEntity>> LOGIN = Event.biConsumer();
+	/**
+	 * This event is fired after login, once channel registration is complete.
+	 * This marks the moment data can safely be sent to the client.
+	 * This applies to connections to dedicated servers as
+	 * well as connections to integrated servers.
+	 */
+	public static final Event<BiConsumer<MinecraftServer, ServerPlayerEntity>> PLAY_READY = Event.biConsumer();
 	/**
 	 * This event is fired when a client disconnects from the server.
 	 * This applies to connections to dedicated servers as

--- a/libraries/networking/networking-mc14w31a-mc1.13-pre2/src/main/java/net/ornithemc/osl/networking/api/server/ServerPlayNetworking.java
+++ b/libraries/networking/networking-mc14w31a-mc1.13-pre2/src/main/java/net/ornithemc/osl/networking/api/server/ServerPlayNetworking.java
@@ -35,6 +35,13 @@ public final class ServerPlayNetworking {
 	}
 
 	/**
+	 * Check whether the connection is ready for data to be sent to the client.
+	 */
+	public static boolean isPlayReady(ServerPlayerEntity player) {
+		return ServerPlayNetworkingImpl.isPlayReady(player);
+	}
+
+	/**
 	 * Check whether the given channel is open for data to be sent through it.
 	 * This method will return {@code false} if the client has no listeners for
 	 * the given channel.

--- a/libraries/networking/networking-mc14w31a-mc1.13-pre2/src/main/java/net/ornithemc/osl/networking/impl/Networking.java
+++ b/libraries/networking/networking-mc14w31a-mc1.13-pre2/src/main/java/net/ornithemc/osl/networking/impl/Networking.java
@@ -29,12 +29,7 @@ public class Networking implements ModInitializer, ClientModInitializer {
 			ServerPlayNetworkingImpl.destroy(server);
 		});
 		ServerPlayNetworking.registerListener(CommonChannels.CHANNELS, (server, handler, player, data) -> {
-			Set<String> channels = readChannels(data);
-
-			if (!channels.isEmpty()) {
-				((IServerPlayNetworkHandler)handler).osl$networking$registerClientChannels(channels);
-			}
-
+			((IServerPlayNetworkHandler)handler).osl$networking$registerClientChannels(readChannels(data));
 			ServerConnectionEvents.PLAY_READY.invoker().accept(server, player);
 
 			return true;
@@ -50,12 +45,7 @@ public class Networking implements ModInitializer, ClientModInitializer {
 			ClientPlayNetworkingImpl.destroy(minecraft);
 		});
 		ClientPlayNetworking.registerListener(CommonChannels.CHANNELS, (minecraft, handler, data) -> {
-			Set<String> channels = readChannels(data);
-
-			if (!channels.isEmpty()) {
-				((IClientPlayNetworkHandler)handler).osl$networking$registerServerChannels(channels);
-			}
-
+			((IClientPlayNetworkHandler)handler).osl$networking$registerServerChannels(readChannels(data));
 			ClientConnectionEvents.PLAY_READY.invoker().accept(minecraft);
 
 			return true;

--- a/libraries/networking/networking-mc14w31a-mc1.13-pre2/src/main/java/net/ornithemc/osl/networking/impl/Networking.java
+++ b/libraries/networking/networking-mc14w31a-mc1.13-pre2/src/main/java/net/ornithemc/osl/networking/impl/Networking.java
@@ -29,6 +29,11 @@ public class Networking implements ModInitializer, ClientModInitializer {
 			ServerPlayNetworkingImpl.destroy(server);
 		});
 		ServerPlayNetworking.registerListener(CommonChannels.CHANNELS, (server, handler, player, data) -> {
+			// send channel registration data as a response to receiving client channel registration data
+			ServerPlayNetworkingImpl.doSend(player, CommonChannels.CHANNELS, response -> {
+				Networking.writeChannels(response, ServerPlayNetworkingImpl.LISTENERS.keySet());
+			});
+
 			((IServerPlayNetworkHandler)handler).osl$networking$registerClientChannels(readChannels(data));
 			ServerConnectionEvents.PLAY_READY.invoker().accept(server, player);
 

--- a/libraries/networking/networking-mc14w31a-mc1.13-pre2/src/main/java/net/ornithemc/osl/networking/impl/Networking.java
+++ b/libraries/networking/networking-mc14w31a-mc1.13-pre2/src/main/java/net/ornithemc/osl/networking/impl/Networking.java
@@ -9,14 +9,16 @@ import net.ornithemc.osl.entrypoints.api.ModInitializer;
 import net.ornithemc.osl.entrypoints.api.client.ClientModInitializer;
 import net.ornithemc.osl.lifecycle.api.client.MinecraftClientEvents;
 import net.ornithemc.osl.lifecycle.api.server.MinecraftServerEvents;
+import net.ornithemc.osl.networking.api.client.ClientConnectionEvents;
 import net.ornithemc.osl.networking.api.client.ClientPlayNetworking;
+import net.ornithemc.osl.networking.api.server.ServerConnectionEvents;
 import net.ornithemc.osl.networking.api.server.ServerPlayNetworking;
 import net.ornithemc.osl.networking.impl.client.ClientPlayNetworkingImpl;
 import net.ornithemc.osl.networking.impl.interfaces.mixin.IClientPlayNetworkHandler;
 import net.ornithemc.osl.networking.impl.interfaces.mixin.IServerPlayNetworkHandler;
 import net.ornithemc.osl.networking.impl.server.ServerPlayNetworkingImpl;
 
-public class NetworkingInitializer implements ModInitializer, ClientModInitializer {
+public class Networking implements ModInitializer, ClientModInitializer {
 
 	@Override
 	public void init() {
@@ -32,6 +34,8 @@ public class NetworkingInitializer implements ModInitializer, ClientModInitializ
 			if (!channels.isEmpty()) {
 				((IServerPlayNetworkHandler)handler).osl$networking$registerClientChannels(channels);
 			}
+
+			ServerConnectionEvents.PLAY_READY.invoker().accept(server, player);
 
 			return true;
 		});
@@ -51,6 +55,8 @@ public class NetworkingInitializer implements ModInitializer, ClientModInitializ
 			if (!channels.isEmpty()) {
 				((IClientPlayNetworkHandler)handler).osl$networking$registerServerChannels(channels);
 			}
+
+			ClientConnectionEvents.PLAY_READY.invoker().accept(minecraft);
 
 			return true;
 		});

--- a/libraries/networking/networking-mc14w31a-mc1.13-pre2/src/main/java/net/ornithemc/osl/networking/impl/client/ClientPlayNetworkingImpl.java
+++ b/libraries/networking/networking-mc14w31a-mc1.13-pre2/src/main/java/net/ornithemc/osl/networking/impl/client/ClientPlayNetworkingImpl.java
@@ -76,6 +76,11 @@ public final class ClientPlayNetworkingImpl {
 		return false;
 	}
 
+	public static boolean isPlayReady() {
+		IClientPlayNetworkHandler handler = (IClientPlayNetworkHandler)minecraft.getNetworkHandler();
+		return handler != null && handler.osl$networking$isPlayReady();
+	}
+
 	public static boolean canSend(String channel) {
 		IClientPlayNetworkHandler handler = (IClientPlayNetworkHandler)minecraft.getNetworkHandler();
 		return handler != null && handler.osl$networking$isRegisteredServerChannel(channel);

--- a/libraries/networking/networking-mc14w31a-mc1.13-pre2/src/main/java/net/ornithemc/osl/networking/impl/interfaces/mixin/IClientPlayNetworkHandler.java
+++ b/libraries/networking/networking-mc14w31a-mc1.13-pre2/src/main/java/net/ornithemc/osl/networking/impl/interfaces/mixin/IClientPlayNetworkHandler.java
@@ -4,6 +4,8 @@ import java.util.Set;
 
 public interface IClientPlayNetworkHandler {
 
+	boolean osl$networking$isPlayReady();
+
 	void osl$networking$registerServerChannels(Set<String> channels);
 
 	boolean osl$networking$isRegisteredServerChannel(String channel);

--- a/libraries/networking/networking-mc14w31a-mc1.13-pre2/src/main/java/net/ornithemc/osl/networking/impl/interfaces/mixin/IServerPlayNetworkHandler.java
+++ b/libraries/networking/networking-mc14w31a-mc1.13-pre2/src/main/java/net/ornithemc/osl/networking/impl/interfaces/mixin/IServerPlayNetworkHandler.java
@@ -4,6 +4,8 @@ import java.util.Set;
 
 public interface IServerPlayNetworkHandler {
 
+	boolean osl$networking$isPlayReady();
+
 	void osl$networking$registerClientChannels(Set<String> channels);
 
 	boolean osl$networking$isRegisteredClientChannel(String channel);

--- a/libraries/networking/networking-mc14w31a-mc1.13-pre2/src/main/java/net/ornithemc/osl/networking/impl/mixin/client/ClientPlayNetworkHandlerMixin.java
+++ b/libraries/networking/networking-mc14w31a-mc1.13-pre2/src/main/java/net/ornithemc/osl/networking/impl/mixin/client/ClientPlayNetworkHandlerMixin.java
@@ -9,7 +9,6 @@ import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.At.Shift;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 import net.minecraft.client.Minecraft;
@@ -35,25 +34,15 @@ public class ClientPlayNetworkHandlerMixin implements IClientPlayNetworkHandler 
 	@Inject(
 		method = "handleLogin",
 		at = @At(
-			value = "INVOKE",
-			shift = Shift.AFTER,
-			target = "Lnet/minecraft/network/PacketUtils;ensureOnSameThread(Lnet/minecraft/network/packet/Packet;Lnet/minecraft/network/handler/PacketHandler;Lnet/minecraft/util/BlockableEventLoop;)V"
-		)
-	)
-	private void osl$networking$registerChannels(CallbackInfo ci) {
-		// send channel registration data as soon as login occurs
-		ClientPlayNetworkingImpl.doSend(CommonChannels.CHANNELS, data -> {
-			Networking.writeChannels(data, ClientPlayNetworkingImpl.LISTENERS.keySet());
-		});
-	}
-
-	@Inject(
-		method = "handleLogin",
-		at = @At(
 			value = "TAIL"
 		)
 	)
 	private void osl$networking$handleLogin(CallbackInfo ci) {
+		// send channel registration data as soon as login occurs
+		ClientPlayNetworkingImpl.doSend(CommonChannels.CHANNELS, data -> {
+			Networking.writeChannels(data, ClientPlayNetworkingImpl.LISTENERS.keySet());
+		});
+
 		ClientConnectionEvents.LOGIN.invoker().accept(minecraft);
 	}
 

--- a/libraries/networking/networking-mc14w31a-mc1.13-pre2/src/main/java/net/ornithemc/osl/networking/impl/mixin/client/ClientPlayNetworkHandlerMixin.java
+++ b/libraries/networking/networking-mc14w31a-mc1.13-pre2/src/main/java/net/ornithemc/osl/networking/impl/mixin/client/ClientPlayNetworkHandlerMixin.java
@@ -82,6 +82,6 @@ public class ClientPlayNetworkHandlerMixin implements IClientPlayNetworkHandler 
 
 	@Override
 	public boolean osl$networking$isRegisteredServerChannel(String channel) {
-		return serverChannels.contains(channel);
+		return serverChannels != null && serverChannels.contains(channel);
 	}
 }

--- a/libraries/networking/networking-mc14w31a-mc1.13-pre2/src/main/java/net/ornithemc/osl/networking/impl/mixin/common/PlayerManagerMixin.java
+++ b/libraries/networking/networking-mc14w31a-mc1.13-pre2/src/main/java/net/ornithemc/osl/networking/impl/mixin/common/PlayerManagerMixin.java
@@ -15,30 +15,13 @@ import net.minecraft.server.PlayerManager;
 import net.minecraft.server.entity.living.player.ServerPlayerEntity;
 
 import net.ornithemc.osl.networking.api.server.ServerConnectionEvents;
-import net.ornithemc.osl.networking.impl.CommonChannels;
-import net.ornithemc.osl.networking.impl.Networking;
 import net.ornithemc.osl.networking.impl.interfaces.mixin.IPlayerManager;
-import net.ornithemc.osl.networking.impl.server.ServerPlayNetworkingImpl;
 
 @Mixin(PlayerManager.class)
 public class PlayerManagerMixin implements IPlayerManager {
 
 	@Shadow @Final private MinecraftServer server;
 	@Shadow @Final private List<ServerPlayerEntity> players;
-
-	@Inject(
-		method = "onLogin",
-		at = @At(
-			value = "NEW",
-			target = "Lnet/minecraft/network/packet/s2c/play/LoginS2CPacket;"
-		)
-	)
-	private void osl$networking$registerChannels(Connection connection, ServerPlayerEntity player, CallbackInfo ci) {
-		// send channel registration data as soon as login occurs
-		ServerPlayNetworkingImpl.doSend(player, CommonChannels.CHANNELS, data -> {
-			Networking.writeChannels(data, ServerPlayNetworkingImpl.LISTENERS.keySet());
-		});
-	}
 
 	@Inject(
 		method = "onLogin",

--- a/libraries/networking/networking-mc14w31a-mc1.13-pre2/src/main/java/net/ornithemc/osl/networking/impl/mixin/common/PlayerManagerMixin.java
+++ b/libraries/networking/networking-mc14w31a-mc1.13-pre2/src/main/java/net/ornithemc/osl/networking/impl/mixin/common/PlayerManagerMixin.java
@@ -16,7 +16,7 @@ import net.minecraft.server.entity.living.player.ServerPlayerEntity;
 
 import net.ornithemc.osl.networking.api.server.ServerConnectionEvents;
 import net.ornithemc.osl.networking.impl.CommonChannels;
-import net.ornithemc.osl.networking.impl.NetworkingInitializer;
+import net.ornithemc.osl.networking.impl.Networking;
 import net.ornithemc.osl.networking.impl.interfaces.mixin.IPlayerManager;
 import net.ornithemc.osl.networking.impl.server.ServerPlayNetworkingImpl;
 
@@ -34,8 +34,9 @@ public class PlayerManagerMixin implements IPlayerManager {
 		)
 	)
 	private void osl$networking$registerChannels(Connection connection, ServerPlayerEntity player, CallbackInfo ci) {
+		// send channel registration data as soon as login occurs
 		ServerPlayNetworkingImpl.doSend(player, CommonChannels.CHANNELS, data -> {
-			NetworkingInitializer.writeChannels(data, ServerPlayNetworkingImpl.LISTENERS.keySet());
+			Networking.writeChannels(data, ServerPlayNetworkingImpl.LISTENERS.keySet());
 		});
 	}
 

--- a/libraries/networking/networking-mc14w31a-mc1.13-pre2/src/main/java/net/ornithemc/osl/networking/impl/mixin/common/ServerPlayNetworkHandlerMixin.java
+++ b/libraries/networking/networking-mc14w31a-mc1.13-pre2/src/main/java/net/ornithemc/osl/networking/impl/mixin/common/ServerPlayNetworkHandlerMixin.java
@@ -67,6 +67,6 @@ public class ServerPlayNetworkHandlerMixin implements IServerPlayNetworkHandler 
 
 	@Override
 	public boolean osl$networking$isRegisteredClientChannel(String channel) {
-		return clientChannels.contains(channel);
+		return clientChannels != null && clientChannels.contains(channel);
 	}
 }

--- a/libraries/networking/networking-mc14w31a-mc1.13-pre2/src/main/java/net/ornithemc/osl/networking/impl/mixin/common/ServerPlayNetworkHandlerMixin.java
+++ b/libraries/networking/networking-mc14w31a-mc1.13-pre2/src/main/java/net/ornithemc/osl/networking/impl/mixin/common/ServerPlayNetworkHandlerMixin.java
@@ -29,7 +29,7 @@ public class ServerPlayNetworkHandlerMixin implements IServerPlayNetworkHandler 
 	/**
 	 * Channels that the client is listening to.
 	 */
-	@Unique private final Set<String> clientChannels = new LinkedHashSet<>();
+	@Unique private Set<String> clientChannels;
 
 	@Inject(
 		method = "onDisconnect",
@@ -39,7 +39,7 @@ public class ServerPlayNetworkHandlerMixin implements IServerPlayNetworkHandler 
 	)
 	private void osl$networking$handleDisconnect(CallbackInfo ci) {
 		ServerConnectionEvents.DISCONNECT.invoker().accept(server, player);
-		clientChannels.clear();
+		clientChannels = null;
 	}
 
 	@Inject(
@@ -56,8 +56,13 @@ public class ServerPlayNetworkHandlerMixin implements IServerPlayNetworkHandler 
 	}
 
 	@Override
+	public boolean osl$networking$isPlayReady() {
+		return clientChannels != null;
+	}
+
+	@Override
 	public void osl$networking$registerClientChannels(Set<String> channels) {
-		clientChannels.addAll(channels);
+		clientChannels = new LinkedHashSet<>(channels);
 	}
 
 	@Override

--- a/libraries/networking/networking-mc14w31a-mc1.13-pre2/src/main/java/net/ornithemc/osl/networking/impl/server/ServerPlayNetworkingImpl.java
+++ b/libraries/networking/networking-mc14w31a-mc1.13-pre2/src/main/java/net/ornithemc/osl/networking/impl/server/ServerPlayNetworkingImpl.java
@@ -81,8 +81,14 @@ public final class ServerPlayNetworkingImpl {
 		return false;
 	}
 
+	public static boolean isPlayReady(ServerPlayerEntity player) {
+		IServerPlayNetworkHandler handler = (IServerPlayNetworkHandler)player.networkHandler;
+		return handler != null && handler.osl$networking$isPlayReady();
+	}
+
 	public static boolean canSend(ServerPlayerEntity player, String channel) {
-		return ((IServerPlayNetworkHandler)player.networkHandler).osl$networking$isRegisteredClientChannel(channel);
+		IServerPlayNetworkHandler handler = (IServerPlayNetworkHandler)player.networkHandler;
+		return handler != null && handler.osl$networking$isRegisteredClientChannel(channel);
 	}
 
 	public static void send(ServerPlayerEntity player, String channel, Consumer<PacketByteBuf> writer) {

--- a/libraries/networking/networking-mc18w31a-mc1.13.2/src/main/java/net/ornithemc/osl/networking/api/client/ClientConnectionEvents.java
+++ b/libraries/networking/networking-mc18w31a-mc1.13.2/src/main/java/net/ornithemc/osl/networking/api/client/ClientConnectionEvents.java
@@ -10,10 +10,19 @@ public class ClientConnectionEvents {
 
 	/**
 	 * This event is fired after a successful login occurs.
+	 * Note that channel registration happens after login,
+	 * and until then data cannot safely be sent to the server.
 	 * This applies to connections to dedicated servers as
 	 * well as connections to integrated servers.
 	 */
 	public static final Event<Consumer<Minecraft>> LOGIN = Event.consumer();
+	/**
+	 * This event is fired after login, once channel registration is complete.
+	 * This marks the moment data can safely be sent to the server.
+	 * This applies to connections to dedicated servers as
+	 * well as connections to integrated servers.
+	 */
+	public static final Event<Consumer<Minecraft>> PLAY_READY = Event.consumer();
 	/**
 	 * This event is fired when the client disconnects from the server.
 	 * This applies to connections to dedicated servers as

--- a/libraries/networking/networking-mc18w31a-mc1.13.2/src/main/java/net/ornithemc/osl/networking/api/client/ClientPlayNetworking.java
+++ b/libraries/networking/networking-mc18w31a-mc1.13.2/src/main/java/net/ornithemc/osl/networking/api/client/ClientPlayNetworking.java
@@ -35,6 +35,13 @@ public final class ClientPlayNetworking {
 	}
 
 	/**
+	 * Check whether the connection is ready for data to be sent to the server.
+	 */
+	public static boolean isPlayReady() {
+		return ClientPlayNetworkingImpl.isPlayReady();
+	}
+
+	/**
 	 * Check whether the given channel is open for data to be sent through it.
 	 * This method will return {@code false} if the client is not connected to a
 	 * server, or if the server has no listeners for the given channel.

--- a/libraries/networking/networking-mc18w31a-mc1.13.2/src/main/java/net/ornithemc/osl/networking/api/server/ServerConnectionEvents.java
+++ b/libraries/networking/networking-mc18w31a-mc1.13.2/src/main/java/net/ornithemc/osl/networking/api/server/ServerConnectionEvents.java
@@ -11,10 +11,19 @@ public class ServerConnectionEvents {
 
 	/**
 	 * This event is fired after a successful login occurs.
+	 * Note that channel registration happens after login,
+	 * and until then data cannot safely be sent to the client.
 	 * This applies to connections to dedicated servers as
 	 * well as connections to integrated servers.
 	 */
 	public static final Event<BiConsumer<MinecraftServer, ServerPlayerEntity>> LOGIN = Event.biConsumer();
+	/**
+	 * This event is fired after login, once channel registration is complete.
+	 * This marks the moment data can safely be sent to the client.
+	 * This applies to connections to dedicated servers as
+	 * well as connections to integrated servers.
+	 */
+	public static final Event<BiConsumer<MinecraftServer, ServerPlayerEntity>> PLAY_READY = Event.biConsumer();
 	/**
 	 * This event is fired when a client disconnects from the server.
 	 * This applies to connections to dedicated servers as

--- a/libraries/networking/networking-mc18w31a-mc1.13.2/src/main/java/net/ornithemc/osl/networking/api/server/ServerPlayNetworking.java
+++ b/libraries/networking/networking-mc18w31a-mc1.13.2/src/main/java/net/ornithemc/osl/networking/api/server/ServerPlayNetworking.java
@@ -37,6 +37,13 @@ public final class ServerPlayNetworking {
 	}
 
 	/**
+	 * Check whether the connection is ready for data to be sent to the client.
+	 */
+	public static boolean isPlayReady(ServerPlayerEntity player) {
+		return ServerPlayNetworkingImpl.isPlayReady(player);
+	}
+
+	/**
 	 * Check whether the given channel is open for data to be sent through it.
 	 * This method will return {@code false} if the client has no listeners for
 	 * the given channel.

--- a/libraries/networking/networking-mc18w31a-mc1.13.2/src/main/java/net/ornithemc/osl/networking/impl/Networking.java
+++ b/libraries/networking/networking-mc18w31a-mc1.13.2/src/main/java/net/ornithemc/osl/networking/impl/Networking.java
@@ -10,14 +10,16 @@ import net.ornithemc.osl.entrypoints.api.ModInitializer;
 import net.ornithemc.osl.entrypoints.api.client.ClientModInitializer;
 import net.ornithemc.osl.lifecycle.api.client.MinecraftClientEvents;
 import net.ornithemc.osl.lifecycle.api.server.MinecraftServerEvents;
+import net.ornithemc.osl.networking.api.client.ClientConnectionEvents;
 import net.ornithemc.osl.networking.api.client.ClientPlayNetworking;
+import net.ornithemc.osl.networking.api.server.ServerConnectionEvents;
 import net.ornithemc.osl.networking.api.server.ServerPlayNetworking;
 import net.ornithemc.osl.networking.impl.client.ClientPlayNetworkingImpl;
 import net.ornithemc.osl.networking.impl.interfaces.mixin.IClientPlayNetworkHandler;
 import net.ornithemc.osl.networking.impl.interfaces.mixin.IServerPlayNetworkHandler;
 import net.ornithemc.osl.networking.impl.server.ServerPlayNetworkingImpl;
 
-public class NetworkingInitializer implements ModInitializer, ClientModInitializer {
+public class Networking implements ModInitializer, ClientModInitializer {
 
 	@Override
 	public void init() {
@@ -28,11 +30,8 @@ public class NetworkingInitializer implements ModInitializer, ClientModInitializ
 			ServerPlayNetworkingImpl.destroy(server);
 		});
 		ServerPlayNetworking.registerListener(CommonChannels.CHANNELS, (server, handler, player, data) -> {
-			Set<Identifier> channels = readChannels(data);
-
-			if (!channels.isEmpty()) {
-				((IServerPlayNetworkHandler)handler).osl$networking$registerClientChannels(channels);
-			}
+			((IServerPlayNetworkHandler)handler).osl$networking$registerClientChannels(readChannels(data));
+			ServerConnectionEvents.PLAY_READY.invoker().accept(server, player);
 
 			return true;
 		});
@@ -47,11 +46,8 @@ public class NetworkingInitializer implements ModInitializer, ClientModInitializ
 			ClientPlayNetworkingImpl.destroy(minecraft);
 		});
 		ClientPlayNetworking.registerListener(CommonChannels.CHANNELS, (minecraft, handler, data) -> {
-			Set<Identifier> channels = readChannels(data);
-
-			if (!channels.isEmpty()) {
-				((IClientPlayNetworkHandler)handler).osl$networking$registerServerChannels(channels);
-			}
+			((IClientPlayNetworkHandler)handler).osl$networking$registerServerChannels(readChannels(data));
+			ClientConnectionEvents.PLAY_READY.invoker().accept(minecraft);
 
 			return true;
 		});

--- a/libraries/networking/networking-mc18w31a-mc1.13.2/src/main/java/net/ornithemc/osl/networking/impl/Networking.java
+++ b/libraries/networking/networking-mc18w31a-mc1.13.2/src/main/java/net/ornithemc/osl/networking/impl/Networking.java
@@ -30,6 +30,11 @@ public class Networking implements ModInitializer, ClientModInitializer {
 			ServerPlayNetworkingImpl.destroy(server);
 		});
 		ServerPlayNetworking.registerListener(CommonChannels.CHANNELS, (server, handler, player, data) -> {
+			// send channel registration data as a response to receiving client channel registration data
+			ServerPlayNetworkingImpl.doSend(player, CommonChannels.CHANNELS, response -> {
+				Networking.writeChannels(response, ServerPlayNetworkingImpl.LISTENERS.keySet());
+			});
+
 			((IServerPlayNetworkHandler)handler).osl$networking$registerClientChannels(readChannels(data));
 			ServerConnectionEvents.PLAY_READY.invoker().accept(server, player);
 

--- a/libraries/networking/networking-mc18w31a-mc1.13.2/src/main/java/net/ornithemc/osl/networking/impl/client/ClientPlayNetworkingImpl.java
+++ b/libraries/networking/networking-mc18w31a-mc1.13.2/src/main/java/net/ornithemc/osl/networking/impl/client/ClientPlayNetworkingImpl.java
@@ -77,6 +77,11 @@ public final class ClientPlayNetworkingImpl {
 		return false;
 	}
 
+	public static boolean isPlayReady() {
+		IClientPlayNetworkHandler handler = (IClientPlayNetworkHandler)minecraft.getNetworkHandler();
+		return handler != null && handler.osl$networking$isPlayReady();
+	}
+
 	public static boolean canSend(Identifier channel) {
 		IClientPlayNetworkHandler handler = (IClientPlayNetworkHandler)minecraft.getNetworkHandler();
 		return handler != null && handler.osl$networking$isRegisteredServerChannel(channel);

--- a/libraries/networking/networking-mc18w31a-mc1.13.2/src/main/java/net/ornithemc/osl/networking/impl/interfaces/mixin/IClientPlayNetworkHandler.java
+++ b/libraries/networking/networking-mc18w31a-mc1.13.2/src/main/java/net/ornithemc/osl/networking/impl/interfaces/mixin/IClientPlayNetworkHandler.java
@@ -6,6 +6,8 @@ import net.minecraft.resource.Identifier;
 
 public interface IClientPlayNetworkHandler {
 
+	boolean osl$networking$isPlayReady();
+
 	void osl$networking$registerServerChannels(Set<Identifier> channels);
 
 	boolean osl$networking$isRegisteredServerChannel(Identifier channel);

--- a/libraries/networking/networking-mc18w31a-mc1.13.2/src/main/java/net/ornithemc/osl/networking/impl/interfaces/mixin/IServerPlayNetworkHandler.java
+++ b/libraries/networking/networking-mc18w31a-mc1.13.2/src/main/java/net/ornithemc/osl/networking/impl/interfaces/mixin/IServerPlayNetworkHandler.java
@@ -6,6 +6,8 @@ import net.minecraft.resource.Identifier;
 
 public interface IServerPlayNetworkHandler {
 
+	boolean osl$networking$isPlayReady();
+
 	void osl$networking$registerClientChannels(Set<Identifier> channels);
 
 	boolean osl$networking$isRegisteredClientChannel(Identifier channel);

--- a/libraries/networking/networking-mc18w31a-mc1.13.2/src/main/java/net/ornithemc/osl/networking/impl/mixin/client/ClientPlayNetworkHandlerMixin.java
+++ b/libraries/networking/networking-mc18w31a-mc1.13.2/src/main/java/net/ornithemc/osl/networking/impl/mixin/client/ClientPlayNetworkHandlerMixin.java
@@ -83,6 +83,6 @@ public class ClientPlayNetworkHandlerMixin implements IClientPlayNetworkHandler 
 
 	@Override
 	public boolean osl$networking$isRegisteredServerChannel(Identifier channel) {
-		return serverChannels.contains(channel);
+		return serverChannels != null && serverChannels.contains(channel);
 	}
 }

--- a/libraries/networking/networking-mc18w31a-mc1.13.2/src/main/java/net/ornithemc/osl/networking/impl/mixin/client/ClientPlayNetworkHandlerMixin.java
+++ b/libraries/networking/networking-mc18w31a-mc1.13.2/src/main/java/net/ornithemc/osl/networking/impl/mixin/client/ClientPlayNetworkHandlerMixin.java
@@ -18,7 +18,7 @@ import net.minecraft.resource.Identifier;
 
 import net.ornithemc.osl.networking.api.client.ClientConnectionEvents;
 import net.ornithemc.osl.networking.impl.CommonChannels;
-import net.ornithemc.osl.networking.impl.NetworkingInitializer;
+import net.ornithemc.osl.networking.impl.Networking;
 import net.ornithemc.osl.networking.impl.client.ClientPlayNetworkingImpl;
 import net.ornithemc.osl.networking.impl.interfaces.mixin.IClientPlayNetworkHandler;
 
@@ -30,7 +30,7 @@ public class ClientPlayNetworkHandlerMixin implements IClientPlayNetworkHandler 
 	/**
 	 * Channels that the server is listening to.
 	 */
-	@Unique private final Set<Identifier> serverChannels = new LinkedHashSet<>();
+	@Unique private Set<Identifier> serverChannels;
 
 	@Inject(
 		method = "handleLogin",
@@ -39,8 +39,9 @@ public class ClientPlayNetworkHandlerMixin implements IClientPlayNetworkHandler 
 		)
 	)
 	private void osl$networking$handleLogin(CallbackInfo ci) {
+		// send channel registration data as soon as login occurs
 		ClientPlayNetworkingImpl.doSend(CommonChannels.CHANNELS, data -> {
-			NetworkingInitializer.writeChannels(data, ClientPlayNetworkingImpl.LISTENERS.keySet());
+			Networking.writeChannels(data, ClientPlayNetworkingImpl.LISTENERS.keySet());
 		});
 
 		ClientConnectionEvents.LOGIN.invoker().accept(minecraft);
@@ -54,7 +55,7 @@ public class ClientPlayNetworkHandlerMixin implements IClientPlayNetworkHandler 
 	)
 	private void osl$networking$handleDisconnect(CallbackInfo ci) {
 		ClientConnectionEvents.DISCONNECT.invoker().accept(minecraft);
-		serverChannels.clear();
+		serverChannels = null;
 	}
 
 	@Inject(
@@ -71,8 +72,13 @@ public class ClientPlayNetworkHandlerMixin implements IClientPlayNetworkHandler 
 	}
 
 	@Override
+	public boolean osl$networking$isPlayReady() {
+		return serverChannels != null;
+	}
+
+	@Override
 	public void osl$networking$registerServerChannels(Set<Identifier> channels) {
-		serverChannels.addAll(channels);
+		serverChannels = new LinkedHashSet<>(channels);
 	}
 
 	@Override

--- a/libraries/networking/networking-mc18w31a-mc1.13.2/src/main/java/net/ornithemc/osl/networking/impl/mixin/common/PlayerManagerMixin.java
+++ b/libraries/networking/networking-mc18w31a-mc1.13.2/src/main/java/net/ornithemc/osl/networking/impl/mixin/common/PlayerManagerMixin.java
@@ -14,7 +14,7 @@ import net.minecraft.server.entity.living.player.ServerPlayerEntity;
 
 import net.ornithemc.osl.networking.api.server.ServerConnectionEvents;
 import net.ornithemc.osl.networking.impl.CommonChannels;
-import net.ornithemc.osl.networking.impl.NetworkingInitializer;
+import net.ornithemc.osl.networking.impl.Networking;
 import net.ornithemc.osl.networking.impl.server.ServerPlayNetworkingImpl;
 
 @Mixin(PlayerManager.class)
@@ -30,8 +30,9 @@ public class PlayerManagerMixin {
 		)
 	)
 	private void osl$networking$registerChannels(Connection connection, ServerPlayerEntity player, CallbackInfo ci) {
+		// send channel registration data as soon as login occurs
 		ServerPlayNetworkingImpl.doSend(player, CommonChannels.CHANNELS, data -> {
-			NetworkingInitializer.writeChannels(data, ServerPlayNetworkingImpl.LISTENERS.keySet());
+			Networking.writeChannels(data, ServerPlayNetworkingImpl.LISTENERS.keySet());
 		});
 	}
 

--- a/libraries/networking/networking-mc18w31a-mc1.13.2/src/main/java/net/ornithemc/osl/networking/impl/mixin/common/PlayerManagerMixin.java
+++ b/libraries/networking/networking-mc18w31a-mc1.13.2/src/main/java/net/ornithemc/osl/networking/impl/mixin/common/PlayerManagerMixin.java
@@ -13,28 +13,11 @@ import net.minecraft.server.PlayerManager;
 import net.minecraft.server.entity.living.player.ServerPlayerEntity;
 
 import net.ornithemc.osl.networking.api.server.ServerConnectionEvents;
-import net.ornithemc.osl.networking.impl.CommonChannels;
-import net.ornithemc.osl.networking.impl.Networking;
-import net.ornithemc.osl.networking.impl.server.ServerPlayNetworkingImpl;
 
 @Mixin(PlayerManager.class)
 public class PlayerManagerMixin {
 
 	@Shadow @Final private MinecraftServer server;
-
-	@Inject(
-		method = "onLogin",
-		at = @At(
-			value = "NEW",
-			target = "Lnet/minecraft/network/packet/s2c/play/LoginS2CPacket;"
-		)
-	)
-	private void osl$networking$registerChannels(Connection connection, ServerPlayerEntity player, CallbackInfo ci) {
-		// send channel registration data as soon as login occurs
-		ServerPlayNetworkingImpl.doSend(player, CommonChannels.CHANNELS, data -> {
-			Networking.writeChannels(data, ServerPlayNetworkingImpl.LISTENERS.keySet());
-		});
-	}
 
 	@Inject(
 		method = "onLogin",

--- a/libraries/networking/networking-mc18w31a-mc1.13.2/src/main/java/net/ornithemc/osl/networking/impl/mixin/common/ServerPlayNetworkHandlerMixin.java
+++ b/libraries/networking/networking-mc18w31a-mc1.13.2/src/main/java/net/ornithemc/osl/networking/impl/mixin/common/ServerPlayNetworkHandlerMixin.java
@@ -30,7 +30,7 @@ public class ServerPlayNetworkHandlerMixin implements IServerPlayNetworkHandler 
 	/**
 	 * Channels that the client is listening to.
 	 */
-	@Unique private final Set<Identifier> clientChannels = new LinkedHashSet<>();
+	@Unique private Set<Identifier> clientChannels;
 
 	@Inject(
 		method = "onDisconnect",
@@ -40,7 +40,7 @@ public class ServerPlayNetworkHandlerMixin implements IServerPlayNetworkHandler 
 	)
 	private void osl$networking$handleDisconnect(CallbackInfo ci) {
 		ServerConnectionEvents.DISCONNECT.invoker().accept(server, player);
-		clientChannels.clear();
+		clientChannels = null;
 	}
 
 	@Inject(
@@ -57,8 +57,13 @@ public class ServerPlayNetworkHandlerMixin implements IServerPlayNetworkHandler 
 	}
 
 	@Override
+	public boolean osl$networking$isPlayReady() {
+		return clientChannels != null;
+	}
+
+	@Override
 	public void osl$networking$registerClientChannels(Set<Identifier> channels) {
-		clientChannels.addAll(channels);
+		clientChannels = new LinkedHashSet<>(channels);
 	}
 
 	@Override

--- a/libraries/networking/networking-mc18w31a-mc1.13.2/src/main/java/net/ornithemc/osl/networking/impl/mixin/common/ServerPlayNetworkHandlerMixin.java
+++ b/libraries/networking/networking-mc18w31a-mc1.13.2/src/main/java/net/ornithemc/osl/networking/impl/mixin/common/ServerPlayNetworkHandlerMixin.java
@@ -68,6 +68,6 @@ public class ServerPlayNetworkHandlerMixin implements IServerPlayNetworkHandler 
 
 	@Override
 	public boolean osl$networking$isRegisteredClientChannel(Identifier channel) {
-		return clientChannels.contains(channel);
+		return clientChannels != null && clientChannels.contains(channel);
 	}
 }

--- a/libraries/networking/networking-mc18w31a-mc1.13.2/src/main/java/net/ornithemc/osl/networking/impl/server/ServerPlayNetworkingImpl.java
+++ b/libraries/networking/networking-mc18w31a-mc1.13.2/src/main/java/net/ornithemc/osl/networking/impl/server/ServerPlayNetworkingImpl.java
@@ -85,8 +85,14 @@ public final class ServerPlayNetworkingImpl {
 		return false;
 	}
 
+	public static boolean isPlayReady(ServerPlayerEntity player) {
+		IServerPlayNetworkHandler handler = (IServerPlayNetworkHandler)player.networkHandler;
+		return handler != null && handler.osl$networking$isPlayReady();
+	}
+
 	public static boolean canSend(ServerPlayerEntity player, Identifier channel) {
-		return ((IServerPlayNetworkHandler)player.networkHandler).osl$networking$isRegisteredClientChannel(channel);
+		IServerPlayNetworkHandler handler = (IServerPlayNetworkHandler)player.networkHandler;
+		return handler != null && handler.osl$networking$isRegisteredClientChannel(channel);
 	}
 
 	public static void send(ServerPlayerEntity player, Identifier channel, Consumer<PacketByteBuf> writer) {

--- a/libraries/networking/src/main/resources/fabric.mod.json
+++ b/libraries/networking/src/main/resources/fabric.mod.json
@@ -18,10 +18,10 @@
 	"environment": "${environment}",
 	"entrypoints": {
 		"client-init": [
-			"net.ornithemc.osl.networking.impl.NetworkingInitializer"
+			"net.ornithemc.osl.networking.impl.Networking"
 		],
 		"init": [
-			"net.ornithemc.osl.networking.impl.NetworkingInitializer"
+			"net.ornithemc.osl.networking.impl.Networking"
 		]
 	},
 	"mixins": [


### PR DESCRIPTION
This PR reworks the implementations of the Networking API in order to fix some issues/bugs with it.

## Issues

Data that is sent during the LOGIN events quietly fails to get through.

### Context

Minecraft has custom payload packets that allow modded instances to send data between the client and server without Vanilla instances freaking out about unknown packets. Vanilla instances simply ignore any custom payloads they do not recognize. In addition to the *data*, custom payloads also have a *channel*. This allows mods to *'tune in'*
 to just their own data, and ignore the data that was targeted at a different mod.

It is good practice for modded instances to only send data over a channel if the other side is listening for data on that channel. Usually this involves initiating a handshake to query whether the other side is listening. If there is no response, the channel is considered closed, and no data should be sent over that channel. If the handshake is reciprocated, the channel is considered open, and data can be sent over that channel. 

OSL handles this by sending channel registration data between the client and server upon login. Once this data is received, both sides know what channels the other is listening to. Mods that use OSL for their networking purposes do not need to check whether the channels they use are open, since OSL does that for them. If the channel is closed, the data is quietly ignored. This is normally perfectly fine, since the channel is only closed when the other side is unmodded and the data should not be sent anyway. However, because the channel registration data is sent upon login, there is a brief window where the connection is in the 'play' phase, and thus, custom payload packets can be sent, but the game has not yet received the channel registration data, and thus all channels are considered closed. This causes all data that is sent during the LOGIN events to be quietly ignored.

## Solution

The obvious solution is to send the channel registration data *before* the connection enters the 'play' phase, and thus have the channel registration completed by the time the LOGIN events are fired. Unfortunately this is not feasible, because it is not possible to send custom payloads during the 'handshake' or 'login' phase. The channel registration data can only be sent during the 'play' phase. It is also not feasible to delay the exchange of login packets until after the channel registration is completed, since that would lead to the login packets being indefinitely delayed for a connection to a Vanilla instance.

However, it turns out it is possible to modify the handshake packet without breaking Vanilla instances at all. Handshake packets contain a few bits of data that the server does absolutely nothing with. Thus, we can replace that data with something else without confusing Vanilla servers, that let modded servers know the client is also modded. This in turn prompts the server to send the channel registration data, which it does immediately after the connection enters the 'play' phase, just before the login packet is sent. The client reciprocates and upon receiving the login packet, can safely fire the LOGIN event since the channel registration happened just before. 

The only loose end is the server side. It either needs to delay the firing of the LOGIN event until it receives the channel registration data, or otherwise any data sent by the server needs to be throttled until the channel registration data is received. Both of these can be safely done since the server already knows during the 'login' phase whether the client is modded at all, and if it isn't, that the server doesn't have to wait for the channel registration data.

### Implementation

The `address` field in the `HandshakeC2SPacket` is unused, thus we replace its value with `"OrnitheMC"`. When the modded server detects that value, it marks the `Connection` as modded. Immediately after the connection enters the 'play' phase, the server sends the channel registration data, just before the login packet is sent. The client receives the packets in that order, and can safely fire the LOGIN event.