### PR TITLE
Fix normalized version of b1.2_02 in lifecycle-events

### DIFF
--- a/libraries/lifecycle-events/lifecycle-events-client-mca1.0.6-mcb1.2_02/gradle.properties
+++ b/libraries/lifecycle-events/lifecycle-events-client-mca1.0.6-mcb1.2_02/gradle.properties
@@ -1,6 +1,6 @@
 environment = client
 min_mc_version = a1.0.6
 max_mc_version = b1.2_02
-mc_version_range = >=1.0.0-alpha.0.6 <=1.0.0-beta.2
+mc_version_range = >=1.0.0-alpha.0.6 <=1.0.0-beta.2.2
 
 feather_build = 9


### PR DESCRIPTION
This looks like it was just a typo and i could run this module just fine on beta 1.2_02 after adapting the fabric.mod.json file.