### PR TITLE
fix #31 in resource-loader

### DIFF
--- a/libraries/resource-loader/resource-loader-mc13w26a-mc1.10.2/src/main/java/net/ornithemc/osl/resource/loader/impl/mixin/client/TranslationStorageMixin.java
+++ b/libraries/resource-loader/resource-loader-mc13w26a-mc1.10.2/src/main/java/net/ornithemc/osl/resource/loader/impl/mixin/client/TranslationStorageMixin.java
@@ -24,29 +24,40 @@ import net.minecraft.client.resource.SimpleResource;
 import net.minecraft.client.resource.language.TranslationStorage;
 import net.minecraft.client.resource.manager.ResourceManager;
 import net.minecraft.resource.Identifier;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(TranslationStorage.class)
-public class TranslationStorageMixin {
+public abstract class TranslationStorageMixin {
 
 	@Final
 	@Shadow
 	private Map<String, String> translations;
 
-	@WrapOperation(
+	@Shadow
+	protected abstract void load(List<?> resources);
+
+	@Inject(
 		method = "load(Lnet/minecraft/client/resource/manager/ResourceManager;Ljava/util/List;)V",
 		at = @At(
 			value = "INVOKE",
-			target = "Lnet/minecraft/client/resource/language/TranslationStorage;load(Ljava/util/List;)V"
+			target = "Lnet/minecraft/client/resource/manager/ResourceManager;getResources(Lnet/minecraft/resource/Identifier;)Ljava/util/List;"
 		)
 	)
-	private void osl$resource_loader$loadTranslationFiles(TranslationStorage instance, List<Resource> resources, Operation<Void> original,
-														  @Local(argsOnly = true) ResourceManager resourceManager, @Local(ordinal = 0) String languageCode,
-														  @Local(ordinal = 1) String originalPath, @Local(ordinal = 2) String namespace) throws IOException {
-		String[] paths = new String[]{originalPath, String.format("lang/%s.json", languageCode),
+	private void osl$resource_loader$loadTranslationFiles(CallbackInfo ci,
+														  @Local(argsOnly = true) ResourceManager resourceManager,
+														  @Local(ordinal = 0) String languageCode,
+														  @Local(ordinal = 2) String namespace) {
+		String[] paths = new String[] {
+			String.format("lang/%s.json", languageCode),
 			String.format("lang/%s.lang", languageCode.toLowerCase(Locale.ROOT)),
-			String.format("lang/%s.json", languageCode.toLowerCase(Locale.ROOT))};
-		for (String path : paths){
-			original.call(instance, resourceManager.getResources(new Identifier(namespace, path)));
+			String.format("lang/%s.json", languageCode.toLowerCase(Locale.ROOT))
+		};
+		for (String path : paths) {
+			try {
+				this.load(resourceManager.getResources(new Identifier(namespace, path)));
+			} catch (IOException ignored) {
+			}
 		}
 	}
 

--- a/libraries/resource-loader/resource-loader-mc13w26a-mc1.10.2/src/main/java/net/ornithemc/osl/resource/loader/impl/mixin/client/TranslationStorageMixin.java
+++ b/libraries/resource-loader/resource-loader-mc13w26a-mc1.10.2/src/main/java/net/ornithemc/osl/resource/loader/impl/mixin/client/TranslationStorageMixin.java
@@ -35,7 +35,7 @@ public abstract class TranslationStorageMixin {
 	private Map<String, String> translations;
 
 	@Shadow
-	protected abstract void load(List<?> resources);
+	protected abstract void load(List<Resource> resources);
 
 	@Inject(
 		method = "load(Lnet/minecraft/client/resource/manager/ResourceManager;Ljava/util/List;)V",

--- a/libraries/resource-loader/resource-loader-mc16w32a-mc1.12.2/src/main/java/net/ornithemc/osl/resource/loader/impl/mixin/client/TranslationStorageMixin.java
+++ b/libraries/resource-loader/resource-loader-mc16w32a-mc1.12.2/src/main/java/net/ornithemc/osl/resource/loader/impl/mixin/client/TranslationStorageMixin.java
@@ -34,7 +34,7 @@ public abstract class TranslationStorageMixin {
 	private Map<String, String> translations;
 
 	@Shadow
-	protected abstract void load(List<?> resources);
+	protected abstract void load(List<Resource> resources);
 
 	@Inject(
 		method = "load(Lnet/minecraft/client/resource/manager/ResourceManager;Ljava/util/List;)V",

--- a/libraries/resource-loader/resource-loader-mc16w32a-mc1.12.2/src/main/java/net/ornithemc/osl/resource/loader/impl/mixin/client/TranslationStorageMixin.java
+++ b/libraries/resource-loader/resource-loader-mc16w32a-mc1.12.2/src/main/java/net/ornithemc/osl/resource/loader/impl/mixin/client/TranslationStorageMixin.java
@@ -23,29 +23,40 @@ import net.minecraft.client.resource.Resource;
 import net.minecraft.client.resource.language.TranslationStorage;
 import net.minecraft.client.resource.manager.ResourceManager;
 import net.minecraft.resource.Identifier;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(TranslationStorage.class)
-public class TranslationStorageMixin {
+public abstract class TranslationStorageMixin {
 
 	@Final
 	@Shadow
 	private Map<String, String> translations;
 
-	@WrapOperation(
+	@Shadow
+	protected abstract void load(List<?> resources);
+
+	@Inject(
 		method = "load(Lnet/minecraft/client/resource/manager/ResourceManager;Ljava/util/List;)V",
 		at = @At(
 			value = "INVOKE",
-			target = "Lnet/minecraft/client/resource/language/TranslationStorage;load(Ljava/util/List;)V"
+			target = "Lnet/minecraft/client/resource/manager/ResourceManager;getResources(Lnet/minecraft/resource/Identifier;)Ljava/util/List;"
 		)
 	)
-	private void osl$resource_loader$loadTranslationFiles(TranslationStorage instance, List<Resource> resources, Operation<Void> original,
-														  @Local(argsOnly = true) ResourceManager resourceManager, @Local(ordinal = 0) String languageCode,
-														  @Local(ordinal = 1) String originalPath, @Local(ordinal = 2) String namespace) throws IOException {
-		String[] paths = new String[]{originalPath, String.format("lang/%s.json", languageCode),
+	private void osl$resource_loader$loadTranslationFiles(CallbackInfo ci,
+														  @Local(argsOnly = true) ResourceManager resourceManager,
+														  @Local(ordinal = 0) String languageCode,
+														  @Local(ordinal = 2) String namespace) {
+		String[] paths = new String[] {
+			String.format("lang/%s.json", languageCode),
 			String.format("lang/%s.lang", languageCode.toLowerCase(Locale.ROOT)),
-			String.format("lang/%s.json", languageCode.toLowerCase(Locale.ROOT))};
-		for (String path : paths){
-			original.call(instance, resourceManager.getResources(new Identifier(namespace, path)));
+			String.format("lang/%s.json", languageCode.toLowerCase(Locale.ROOT))
+		};
+		for (String path : paths) {
+			try {
+				this.load(resourceManager.getResources(new Identifier(namespace, path)));
+			} catch (IOException ignored) {
+			}
 		}
 	}
 

--- a/libraries/resource-loader/resource-loader-mc17w43a-mc19w07a/src/main/java/net/ornithemc/osl/resource/loader/impl/mixin/client/TranslationStorageMixin.java
+++ b/libraries/resource-loader/resource-loader-mc17w43a-mc19w07a/src/main/java/net/ornithemc/osl/resource/loader/impl/mixin/client/TranslationStorageMixin.java
@@ -33,7 +33,7 @@ public abstract class TranslationStorageMixin {
 	private Map<String, String> translations;
 
 	@Shadow
-	protected abstract void load(List<?> resources);
+	protected abstract void load(List<Resource> resources);
 
 	@Inject(
 		method = "load(Lnet/minecraft/client/resource/manager/ResourceManager;Ljava/util/List;)V",

--- a/libraries/resource-loader/resource-loader-mc19w08a-mc1.14.4/src/main/java/net/ornithemc/osl/resource/loader/impl/mixin/client/TranslationStorageMixin.java
+++ b/libraries/resource-loader/resource-loader-mc19w08a-mc1.14.4/src/main/java/net/ornithemc/osl/resource/loader/impl/mixin/client/TranslationStorageMixin.java
@@ -33,7 +33,7 @@ public abstract class TranslationStorageMixin {
 	private Map<String, String> translations;
 
 	@Shadow
-	protected abstract void load(List<?> resources);
+	protected abstract void load(List<Resource> resources);
 
 	@Inject(
 		method = "load(Lnet/minecraft/client/resource/manager/ResourceManager;Ljava/util/List;)V",


### PR DESCRIPTION
Instead of wrapping the `load` call, the alternate lang formats are injected before the argument calling `getResources` is evaluated. Any exception thrown from this argument evaluation will no longer prevent loading of the alternate files.

This changes the evaluation order of the variants but users of these different file name options (`lang/en_US.lang`, `lang/en_US.json`, `lang/en_us.lang`, `lang/en_us.json`) should not expect a specific ordering anyway.