### PR TITLE
[Networking] More reliable fix to prevent null networkhandler

### DIFF
--- a/libraries/networking-impl/networking-impl-mca1.0.16-mca1.2.6/src/main/java/net/ornithemc/osl/networking/impl/Networking.java
+++ b/libraries/networking-impl/networking-impl-mca1.0.16-mca1.2.6/src/main/java/net/ornithemc/osl/networking/impl/Networking.java
@@ -22,10 +22,6 @@ public class Networking implements ModInitializer, ClientModInitializer, ServerM
 		MinecraftClientEvents.STOP.register(ClientPlayNetworkingImpl::destroy);
 		ClientPlayNetworkingImpl.setUpPacketFactory(CustomPayloadPacket::new);
 		ClientPlayNetworkingImpl.registerListener(HandshakePayload.CHANNEL, HandshakePayload::new, (context, payload) -> {
-			// ensure the handshake is processed on the main thread,
-			// where the network handler is guaranteed to be set
-			context.ensureOnMainThread();
-
 			// send channel registration data as a response to receiving server channel registration data
 			ClientPlayNetworkingImpl.sendNoCheck(HandshakePayload.CHANNEL, HandshakePayload.client());
 

--- a/libraries/networking-impl/networking-impl-mcb1.0-mcb1.4_01/src/main/java/net/ornithemc/osl/networking/impl/Networking.java
+++ b/libraries/networking-impl/networking-impl-mcb1.0-mcb1.4_01/src/main/java/net/ornithemc/osl/networking/impl/Networking.java
@@ -25,10 +25,6 @@ public class Networking implements ModInitializer, ClientModInitializer, ServerM
 		MinecraftClientEvents.STOP.register(ClientPlayNetworkingImpl::destroy);
 		ClientPlayNetworkingImpl.setUpPacketFactory(CustomPayloadPacket::new);
 		ClientPlayNetworkingImpl.registerListener(HandshakePayload.CHANNEL, HandshakePayload::new, (context, payload) -> {
-			// ensure the handshake is processed on the main thread,
-			// where the network handler is guaranteed to be set
-			context.ensureOnMainThread();
-
 			// send channel registration data as a response to receiving server channel registration data
 			ClientPlayNetworkingImpl.sendNoCheck(HandshakePayload.CHANNEL, HandshakePayload.client());
 

--- a/libraries/networking-impl/networking-impl-mcb1.5-mc11w48a/src/main/java/net/ornithemc/osl/networking/impl/Networking.java
+++ b/libraries/networking-impl/networking-impl-mcb1.5-mc11w48a/src/main/java/net/ornithemc/osl/networking/impl/Networking.java
@@ -25,10 +25,6 @@ public class Networking implements ModInitializer, ClientModInitializer, ServerM
 		MinecraftClientEvents.STOP.register(ClientPlayNetworkingImpl::destroy);
 		ClientPlayNetworkingImpl.setUpPacketFactory(CustomPayloadPacket::new);
 		ClientPlayNetworkingImpl.registerListener(HandshakePayload.CHANNEL, HandshakePayload::new, (context, payload) -> {
-			// ensure the handshake is processed on the main thread,
-			// where the network handler is guaranteed to be set
-			context.ensureOnMainThread();
-
 			// send channel registration data as a response to receiving server channel registration data
 			ClientPlayNetworkingImpl.sendNoCheck(HandshakePayload.CHANNEL, HandshakePayload.client());
 

--- a/libraries/networking/networking-mc13w41a-mc18w30b/src/main/java/net/ornithemc/osl/networking/impl/client/ClientPlayNetworkingImpl.java
+++ b/libraries/networking/networking-mc13w41a-mc18w30b/src/main/java/net/ornithemc/osl/networking/impl/client/ClientPlayNetworkingImpl.java
@@ -30,6 +30,7 @@ public final class ClientPlayNetworkingImpl {
 
 	private static final Logger LOGGER = LogManager.getLogger("OSL|Client Play Networking");
 
+	private static final ThreadLocal<ClientPlayNetworkHandler> currentHandler = new ThreadLocal<>();
 	private static PacketFactory packetFactory;
 	private static Minecraft minecraft;
 	private static Thread thread;
@@ -111,7 +112,7 @@ public final class ClientPlayNetworkingImpl {
 		ChannelListener listener = CHANNEL_LISTENERS.get(channel);
 
 		if (listener != null) {
-			ChannelListener.Context ctx = new ChannelListener.Context();
+			ChannelListener.Context ctx = new ChannelListener.Context(handler);
 			PacketBuffer data = p.osl$networking$getData();
 
 			try {
@@ -127,10 +128,13 @@ public final class ClientPlayNetworkingImpl {
 	}
 
 	private static void handlePayload(NamespacedIdentifier channel, ChannelListener listener, ChannelListener.Context ctx, PacketBuffer data) {
+		currentHandler.set(ctx.networkHandler());
 		try {
 			listener.handle(ctx, data);
 		} catch (IOException e) {
 			LOGGER.warn("error handling custom payload on channel \'" + channel + "\'", e);
+		} finally {
+			currentHandler.remove();
 		}
 	}
 
@@ -212,7 +216,15 @@ public final class ClientPlayNetworkingImpl {
 		ChannelSettings settings = ChannelRegistryImpl.getSettings(channel);
 
 		if (settings != null && settings.isServerbound()) {
-			minecraft.getNetworkHandler().sendPacket(packetFactory.create(channel, data));
+			ClientPlayNetworkHandler handler = currentHandler.get();
+			if (handler == null) {
+				handler = minecraft.getNetworkHandler();
+			}
+			if (handler != null) {
+				handler.sendPacket(packetFactory.create(channel, data));
+			} else {
+				LOGGER.warn("dropping packet on channel '{}': no network handler available", channel);
+			}
 		}
 	}
 
@@ -223,6 +235,12 @@ public final class ClientPlayNetworkingImpl {
 
 		class Context implements ClientPacketListener.Context {
 
+			private final ClientPlayNetworkHandler handler;
+
+			Context(ClientPlayNetworkHandler handler) {
+				this.handler = handler;
+			}
+
 			@Override
 			public Minecraft minecraft() {
 				return minecraft;
@@ -230,7 +248,7 @@ public final class ClientPlayNetworkingImpl {
 
 			@Override
 			public ClientPlayNetworkHandler networkHandler() {
-				return minecraft.getNetworkHandler();
+				return handler;
 			}
 
 			@Override

--- a/libraries/networking/networking-mc18w31a-mc1.14.4/src/main/java/net/ornithemc/osl/networking/impl/client/ClientPlayNetworkingImpl.java
+++ b/libraries/networking/networking-mc18w31a-mc1.14.4/src/main/java/net/ornithemc/osl/networking/impl/client/ClientPlayNetworkingImpl.java
@@ -30,6 +30,7 @@ public final class ClientPlayNetworkingImpl {
 
 	private static final Logger LOGGER = LogManager.getLogger("OSL|Client Play Networking");
 
+	private static final ThreadLocal<ClientPlayNetworkHandler> currentHandler = new ThreadLocal<>();
 	private static PacketFactory packetFactory;
 	private static Minecraft minecraft;
 	private static Thread thread;
@@ -109,7 +110,7 @@ public final class ClientPlayNetworkingImpl {
 		ChannelListener listener = CHANNEL_LISTENERS.get(channel);
 
 		if (listener != null) {
-			ChannelListener.Context ctx = new ChannelListener.Context();
+			ChannelListener.Context ctx = new ChannelListener.Context(handler);
 			PacketBuffer data = p.osl$networking$getData();
 
 			try {
@@ -125,10 +126,13 @@ public final class ClientPlayNetworkingImpl {
 	}
 
 	private static void handlePayload(NamespacedIdentifier channel, ChannelListener listener, ChannelListener.Context ctx, PacketBuffer data) {
+		currentHandler.set(ctx.networkHandler());
 		try {
 			listener.handle(ctx, data);
 		} catch (IOException e) {
 			LOGGER.warn("error handling custom payload on channel \'" + channel + "\'", e);
+		} finally {
+			currentHandler.remove();
 		}
 	}
 
@@ -210,7 +214,15 @@ public final class ClientPlayNetworkingImpl {
 		ChannelSettings settings = ChannelRegistryImpl.getSettings(channel);
 
 		if (settings != null && settings.isServerbound()) {
-			minecraft.getNetworkHandler().sendPacket(packetFactory.create(channel, data));
+			ClientPlayNetworkHandler handler = currentHandler.get();
+			if (handler == null) {
+				handler = minecraft.getNetworkHandler();
+			}
+			if (handler != null) {
+				handler.sendPacket(packetFactory.create(channel, data));
+			} else {
+				LOGGER.warn("dropping packet on channel '{}': no network handler available", channel);
+			}
 		}
 	}
 
@@ -221,6 +233,12 @@ public final class ClientPlayNetworkingImpl {
 
 		class Context implements ClientPacketListener.Context {
 
+			private final ClientPlayNetworkHandler handler;
+
+			Context(ClientPlayNetworkHandler handler) {
+				this.handler = handler;
+			}
+
 			@Override
 			public Minecraft minecraft() {
 				return minecraft;
@@ -228,7 +246,7 @@ public final class ClientPlayNetworkingImpl {
 
 			@Override
 			public ClientPlayNetworkHandler networkHandler() {
-				return minecraft.getNetworkHandler();
+				return handler;
 			}
 
 			@Override

--- a/libraries/networking/networking-mca1.0.16-mca1.2.6/src/main/java/net/ornithemc/osl/networking/impl/client/ClientPlayNetworkingImpl.java
+++ b/libraries/networking/networking-mca1.0.16-mca1.2.6/src/main/java/net/ornithemc/osl/networking/impl/client/ClientPlayNetworkingImpl.java
@@ -31,6 +31,7 @@ public final class ClientPlayNetworkingImpl {
 
 	private static final Logger LOGGER = LogManager.getLogger("OSL|Client Play Networking");
 
+	private static final ThreadLocal<ClientNetworkHandler> currentHandler = new ThreadLocal<>();
 	private static PacketFactory packetFactory;
 	private static Minecraft minecraft;
 	private static Thread thread;
@@ -110,7 +111,7 @@ public final class ClientPlayNetworkingImpl {
 		ChannelListener listener = CHANNEL_LISTENERS.get(channel);
 
 		if (listener != null) {
-			ChannelListener.Context ctx = new ChannelListener.Context();
+			ChannelListener.Context ctx = new ChannelListener.Context(handler);
 			byte[] data = p.osl$networking$getData();
 
 			try {
@@ -126,10 +127,13 @@ public final class ClientPlayNetworkingImpl {
 	}
 
 	private static void handlePayload(NamespacedIdentifier channel, ChannelListener listener, ChannelListener.Context ctx, byte[] data) {
+		currentHandler.set(ctx.networkHandler());
 		try {
 			listener.handle(ctx, data);
 		} catch (IOException e) {
 			LOGGER.warn("error handling custom payload on channel \'" + channel + "\'", e);
+		} finally {
+			currentHandler.remove();
 		}
 	}
 
@@ -216,7 +220,15 @@ public final class ClientPlayNetworkingImpl {
 		ChannelSettings settings = ChannelRegistryImpl.getSettings(channel);
 
 		if (settings != null && settings.isServerbound()) {
-			networkHandler().sendPacket(packetFactory.create(channel, data));
+			ClientNetworkHandler handler = currentHandler.get();
+			if (handler == null) {
+				handler = networkHandler();
+			}
+			if (handler != null) {
+				handler.sendPacket(packetFactory.create(channel, data));
+			} else {
+				LOGGER.warn("dropping packet on channel '{}': no network handler available", channel);
+			}
 		}
 	}
 
@@ -227,6 +239,12 @@ public final class ClientPlayNetworkingImpl {
 
 		class Context implements ClientPacketListener.Context {
 
+			private final ClientNetworkHandler handler;
+
+			Context(ClientNetworkHandler handler) {
+				this.handler = handler;
+			}
+
 			@Override
 			public Minecraft minecraft() {
 				return minecraft;
@@ -234,7 +252,7 @@ public final class ClientPlayNetworkingImpl {
 
 			@Override
 			public ClientNetworkHandler networkHandler() {
-				return ClientPlayNetworkingImpl.networkHandler();
+				return handler;
 			}
 
 			@Override

--- a/libraries/networking/networking-mcb1.0-mc13w39b/src/main/java/net/ornithemc/osl/networking/impl/client/ClientPlayNetworkingImpl.java
+++ b/libraries/networking/networking-mcb1.0-mc13w39b/src/main/java/net/ornithemc/osl/networking/impl/client/ClientPlayNetworkingImpl.java
@@ -30,6 +30,7 @@ public final class ClientPlayNetworkingImpl {
 
 	private static final Logger LOGGER = LogManager.getLogger("OSL|Client Play Networking");
 
+	private static final ThreadLocal<ClientNetworkHandler> currentHandler = new ThreadLocal<>();
 	private static PacketFactory packetFactory;
 	private static Minecraft minecraft;
 	private static Thread thread;
@@ -109,7 +110,7 @@ public final class ClientPlayNetworkingImpl {
 		ChannelListener listener = CHANNEL_LISTENERS.get(channel);
 
 		if (listener != null) {
-			ChannelListener.Context ctx = new ChannelListener.Context();
+			ChannelListener.Context ctx = new ChannelListener.Context(handler);
 			byte[] data = p.osl$networking$getData();
 
 			try {
@@ -125,10 +126,13 @@ public final class ClientPlayNetworkingImpl {
 	}
 
 	private static void handlePayload(NamespacedIdentifier channel, ChannelListener listener, ChannelListener.Context ctx, byte[] data) {
+		currentHandler.set(ctx.networkHandler());
 		try {
 			listener.handle(ctx, data);
 		} catch (IOException e) {
 			LOGGER.warn("error handling custom payload on channel \'" + channel + "\'", e);
+		} finally {
+			currentHandler.remove();
 		}
 	}
 
@@ -210,7 +214,15 @@ public final class ClientPlayNetworkingImpl {
 		ChannelSettings settings = ChannelRegistryImpl.getSettings(channel);
 
 		if (settings != null && settings.isServerbound()) {
-			minecraft.getNetworkHandler().sendPacket(packetFactory.create(channel, data));
+			ClientNetworkHandler handler = currentHandler.get();
+			if (handler == null) {
+				handler = minecraft.getNetworkHandler();
+			}
+			if (handler != null) {
+				handler.sendPacket(packetFactory.create(channel, data));
+			} else {
+				LOGGER.warn("dropping packet on channel '{}': no network handler available", channel);
+			}
 		}
 	}
 
@@ -221,6 +233,12 @@ public final class ClientPlayNetworkingImpl {
 
 		class Context implements ClientPacketListener.Context {
 
+			private final ClientNetworkHandler handler;
+
+			Context(ClientNetworkHandler handler) {
+				this.handler = handler;
+			}
+
 			@Override
 			public Minecraft minecraft() {
 				return minecraft;
@@ -228,7 +246,7 @@ public final class ClientPlayNetworkingImpl {
 
 			@Override
 			public ClientNetworkHandler networkHandler() {
-				return minecraft.getNetworkHandler();
+				return handler;
 			}
 
 			@Override


### PR DESCRIPTION
With threaded networking, custom payload packets can be received and handled on the network thread, where Minecraft.getNetworkHandler() may return null due to a race condition the handler that delivered the packet may not yet be (or may no longer be) assigned on the Minecraft instance. The previous fix of deferring to the main thread via ensureOnMainThread() didn't fully solve this either, since the handler could still be nulled out between ticks. This fix instead captures the network handler at packet arrival time where it is guaranteed to be non-null and stores it in the Context object and a ThreadLocal so that it is available when sending response packets from within a listener callback. A ThreadLocal is used rather than threading the handler through as a method parameter because sendPacket() is reached through the public send/sendNoCheck API, and changing those signatures would break the end-user API.

I reverted the now unnecessary ensureOnMainThread with this commit/pr as well, which only partially resolved the issue.

I investigated other places where null network handler may be an issue, but the other uses of minecraft.getNetworkHandler() are covered by null checks in isPlayReady, so it's good to go.