### PR TITLE
Keybinds V2

### DIFF
--- a/libraries/keybinds/README.md
+++ b/libraries/keybinds/README.md
@@ -1,26 +1,42 @@
 # Keybinds API
 
-The keybinds API provides events for registering keybinds. You may register a callback to this event in your mod's initializer:
+The Keybinds API provides events and utilities for registering and working with keybinds.
+
+## Registering Custom Keybinds
+
+Keybind registration should be done in a listener to the `REGISTER_KEYBINDS` event. The `KeybindRegistry` class provides utility methods for registering keybinds.
+
+An example is shown below.
 
 ```java
 package com.example;
 
-import net.minecraft.client.options.KeyBinding;
-
 import net.ornithemc.osl.entrypoints.api.client.ClientModInitializer;
-import net.ornithemc.osl.keybinds.api.KeyBindingEvents;
-
-import org.lwjgl.input.Keyboard;
+import net.ornithemc.osl.keybinds.api.KeybindEvents;
 
 public class ExampleInitializer implements ClientModInitializer {
 
-	public static KeyBinding cookieKeybind;
-
 	@Override
 	public void initClient() {
-		KeyBindingEvents.REGISTER_KEYBINDS.register(registry -> {
-			cookieKeybind = registry.register("Cookie", Keyboard.KEY_NONE, "Example Mod");
-		});
+		KeybindEvents.REGISTER_KEYBINDS.register(ExampleKeybinds::init);
+	}
+}
+```
+
+```java
+package com.example;
+
+import org.lwjgl.glfw.GLFW;
+
+import net.minecraft.client.options.KeyBinding;
+
+import net.ornithemc.osl.keybinds.api.KeybindRegistry;
+
+public final class ExampleKeybinds {
+
+	public static final KeyBinding COOKIE = KeybindRegistry.register("cookie", GLFW.GLFW_KEY_Z, "example");
+
+	public static void init() {
 	}
 }
 ```

--- a/libraries/keybinds/keybinds-mc13w36a-mc17w15a/src/main/java/net/ornithemc/osl/keybinds/api/KeyBindingEvents.java
+++ b/libraries/keybinds/keybinds-mc13w36a-mc17w15a/src/main/java/net/ornithemc/osl/keybinds/api/KeyBindingEvents.java
@@ -6,7 +6,10 @@ import net.ornithemc.osl.core.api.events.Event;
 
 /**
  * Events related to Minecraft's keybinds.
+ * 
+ * @deprecated use {@linkplain KeybindEvents} instead
  */
+@Deprecated
 public class KeyBindingEvents {
 
 	/**

--- a/libraries/keybinds/keybinds-mc13w36a-mc17w15a/src/main/java/net/ornithemc/osl/keybinds/api/KeybindEvents.java
+++ b/libraries/keybinds/keybinds-mc13w36a-mc17w15a/src/main/java/net/ornithemc/osl/keybinds/api/KeybindEvents.java
@@ -1,0 +1,34 @@
+package net.ornithemc.osl.keybinds.api;
+
+import net.ornithemc.osl.core.api.events.Event;
+
+/**
+ * Events related to Minecraft's keybinds.
+ */
+public final class KeybindEvents {
+
+	/**
+	 * This event is invoked upon game start-up, before game options are loaded.
+	 * 
+	 * <p>
+	 * Custom keybind registration should be done in a listener of this event.
+	 * Helper methods for registering keybinds can be found in the {@linkplain
+	 * KeybindRegistry} class.
+	 * 
+	 * <p>
+	 * Listeners to this event should be registered in your mod's entrypoint,
+	 * and can be done as follows:
+	 * 
+	 * <pre>
+	 * {@code
+	 * KeybindEvents.REGISTER_KEYBINDS.register(() -> {
+	 * 	KeybindRegistry.register("cookie", Keyboard.KEY_Z, "example");
+	 * });
+	 * }
+	 * </pre>
+	 * 
+	 * @see KeybindRegistry
+	 */
+	public static final Event<Runnable> REGISTER_KEYBINDS = Event.runnable();
+
+}

--- a/libraries/keybinds/keybinds-mc13w36a-mc17w15a/src/main/java/net/ornithemc/osl/keybinds/api/KeybindRegistry.java
+++ b/libraries/keybinds/keybinds-mc13w36a-mc17w15a/src/main/java/net/ornithemc/osl/keybinds/api/KeybindRegistry.java
@@ -1,0 +1,38 @@
+package net.ornithemc.osl.keybinds.api;
+
+import java.util.Set;
+
+import net.minecraft.client.options.KeyBinding;
+
+import net.ornithemc.osl.keybinds.impl.KeybindRegistryImpl;
+
+/**
+ * Public access to the Keybinds registry.
+ */
+public final class KeybindRegistry {
+
+	/**
+	 * @return the set of all keybind categories.
+	 */
+	public static Set<String> getCategories() {
+		return KeybindRegistryImpl.getCategories();
+	}
+
+	/**
+	 * @param name           the name or translation key of the keybind.
+	 * @param defaultKeyCode the default key code of the keybind.
+	 * @param category       the name or translation key of the category to which the keybind belongs.
+	 * @return the registered keybind.
+	 */
+	public static KeyBinding register(String name, int defaultKeyCode, String category) {
+		return KeybindRegistryImpl.register(name, defaultKeyCode, category);
+	}
+
+	/**
+	 * @param keybind the keybind to register.
+	 * @return the registered keybind.
+	 */
+	public static KeyBinding register(KeyBinding keybind) {
+		return KeybindRegistryImpl.register(keybind);
+	}
+}

--- a/libraries/keybinds/keybinds-mc13w36a-mc17w15a/src/main/java/net/ornithemc/osl/keybinds/impl/KeybindRegistryImpl.java
+++ b/libraries/keybinds/keybinds-mc13w36a-mc17w15a/src/main/java/net/ornithemc/osl/keybinds/impl/KeybindRegistryImpl.java
@@ -1,0 +1,76 @@
+package net.ornithemc.osl.keybinds.impl;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+import org.apache.commons.lang3.ArrayUtils;
+
+import net.minecraft.client.options.GameOptions;
+import net.minecraft.client.options.KeyBinding;
+
+import net.ornithemc.osl.keybinds.api.KeyBindingEvents;
+import net.ornithemc.osl.keybinds.api.KeyBindingRegistry;
+import net.ornithemc.osl.keybinds.api.KeybindEvents;
+import net.ornithemc.osl.keybinds.impl.mixin.client.KeyBindingAccessor;
+
+public final class KeybindRegistryImpl {
+
+	private static GameOptions options;
+	private static Set<String> categories;
+
+	private static List<KeyBinding> pendingKeybinds;
+
+	public static Set<String> getCategories() {
+		return categories;
+	}
+
+	public static KeyBinding register(String name, int defaultKeyCode, String category) {
+		return register(new KeyBinding(name, defaultKeyCode, category));
+	}
+
+	public static KeyBinding register(KeyBinding keybind) {
+		addCategory(keybind.getCategory());
+		addKeybind(keybind);
+
+		return keybind;
+	}
+
+	private static void addCategory(String category) {
+		categories.add(category);
+	}
+
+	private static void addKeybind(KeyBinding keybind) {
+		if (pendingKeybinds != null) {
+			pendingKeybinds.add(keybind);
+		} else {
+			// this code path is only reached if register methods are called after
+			// the event has been run - manually append the keybind anyway
+			options.keyBindings = ArrayUtils.addAll(options.keyBindings, keybind);
+		}
+	}
+
+	public static void init(GameOptions gameOptions) {
+		options = gameOptions;
+		categories = KeyBindingAccessor.accessCategories();
+
+		pendingKeybinds = new ArrayList<>();
+
+		KeyBindingEvents.REGISTER_KEYBINDS.invoker().accept(new KeyBindingRegistry() {
+
+			@Override
+			public KeyBinding register(String name, int defaultKeyCode, String category) {
+				return KeybindRegistryImpl.register(name, defaultKeyCode, category);
+			}
+
+			@Override
+			public KeyBinding register(KeyBinding keybind) {
+				return KeybindRegistryImpl.register(keybind);
+			}
+		});
+		KeybindEvents.REGISTER_KEYBINDS.invoker().run();
+
+		options.keyBindings = ArrayUtils.addAll(options.keyBindings, pendingKeybinds.toArray(new KeyBinding[0]));
+		pendingKeybinds = null;
+	}
+}

--- a/libraries/keybinds/keybinds-mc13w36a-mc17w15a/src/main/java/net/ornithemc/osl/keybinds/impl/mixin/client/GameOptionsMixin.java
+++ b/libraries/keybinds/keybinds-mc13w36a-mc17w15a/src/main/java/net/ornithemc/osl/keybinds/impl/mixin/client/GameOptionsMixin.java
@@ -1,25 +1,16 @@
 package net.ornithemc.osl.keybinds.impl.mixin.client;
 
-import java.util.LinkedHashSet;
-import java.util.Set;
-
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 import net.minecraft.client.options.GameOptions;
-import net.minecraft.client.options.KeyBinding;
 
-import net.ornithemc.osl.keybinds.api.KeyBindingEvents;
-import net.ornithemc.osl.keybinds.api.KeyBindingRegistry;
+import net.ornithemc.osl.keybinds.impl.KeybindRegistryImpl;
 
 @Mixin(GameOptions.class)
-public class GameOptionsMixin implements KeyBindingRegistry {
-
-	@Shadow private KeyBinding[] keyBindings;
-	private Set<KeyBinding> modKeyBindings;
+public class GameOptionsMixin {
 
 	@Inject(
 		method = "<init>(Lnet/minecraft/client/Minecraft;Ljava/io/File;)V",
@@ -29,30 +20,6 @@ public class GameOptionsMixin implements KeyBindingRegistry {
 		)
 	)
 	private void osl$keybinds$registerKeybinds(CallbackInfo ci) {
-		modKeyBindings = new LinkedHashSet<>();
-
-		KeyBindingEvents.REGISTER_KEYBINDS.invoker().accept(this);
-
-		KeyBinding[] mcKeybinds = keyBindings;
-		keyBindings = new KeyBinding[mcKeybinds.length + modKeyBindings.size()];
-
-		int i = 0;
-		for (KeyBinding keybind : mcKeybinds) {
-			keyBindings[i++] = keybind;
-		}
-		for (KeyBinding keybind : modKeyBindings) {
-			keyBindings[i++] = keybind;
-		}
-	}
-
-	@Override
-	public KeyBinding register(String name, int defaultKeyCode, String category) {
-		return register(new KeyBinding(name, defaultKeyCode, category));
-	}
-
-	@Override
-	public KeyBinding register(KeyBinding keybind) {
-		modKeyBindings.add(keybind);
-		return keybind;
+		KeybindRegistryImpl.init((GameOptions) (Object) this);
 	}
 }

--- a/libraries/keybinds/keybinds-mc13w36a-mc17w15a/src/main/java/net/ornithemc/osl/keybinds/impl/mixin/client/KeyBindingAccessor.java
+++ b/libraries/keybinds/keybinds-mc13w36a-mc17w15a/src/main/java/net/ornithemc/osl/keybinds/impl/mixin/client/KeyBindingAccessor.java
@@ -1,6 +1,5 @@
 package net.ornithemc.osl.keybinds.impl.mixin.client;
 
-import java.util.Map;
 import java.util.Set;
 
 import org.spongepowered.asm.mixin.Mixin;
@@ -13,11 +12,6 @@ public interface KeyBindingAccessor {
 
 	@Accessor("CATEGORIES")
 	static Set<String> accessCategories() {
-		throw new UnsupportedOperationException();
-	}
-
-	@Accessor("CATEGORY_SORT_ORDER")
-	static Map<String, Integer> accessCategorySortOrder() {
 		throw new UnsupportedOperationException();
 	}
 }

--- a/libraries/keybinds/keybinds-mc13w36a-mc17w15a/src/main/resources/osl.keybinds.mixins.json
+++ b/libraries/keybinds/keybinds-mc13w36a-mc17w15a/src/main/resources/osl.keybinds.mixins.json
@@ -6,7 +6,8 @@
 	"mixins": [
 	],
 	"client": [
-		"client.GameOptionsMixin"
+		"client.GameOptionsMixin",
+		"client.KeyBindingAccessor"
 	],
 	"server": [
 	],

--- a/libraries/keybinds/keybinds-mc17w16a-mc1.12.2/src/main/java/net/ornithemc/osl/keybinds/api/KeyBindingEvents.java
+++ b/libraries/keybinds/keybinds-mc17w16a-mc1.12.2/src/main/java/net/ornithemc/osl/keybinds/api/KeyBindingEvents.java
@@ -6,7 +6,10 @@ import net.ornithemc.osl.core.api.events.Event;
 
 /**
  * Events related to Minecraft's keybinds.
+ * 
+ * @deprecated use {@linkplain KeybindEvents} instead
  */
+@Deprecated
 public class KeyBindingEvents {
 
 	/**

--- a/libraries/keybinds/keybinds-mc17w16a-mc1.12.2/src/main/java/net/ornithemc/osl/keybinds/api/KeybindEvents.java
+++ b/libraries/keybinds/keybinds-mc17w16a-mc1.12.2/src/main/java/net/ornithemc/osl/keybinds/api/KeybindEvents.java
@@ -1,0 +1,34 @@
+package net.ornithemc.osl.keybinds.api;
+
+import net.ornithemc.osl.core.api.events.Event;
+
+/**
+ * Events related to Minecraft's keybinds.
+ */
+public final class KeybindEvents {
+
+	/**
+	 * This event is invoked upon game start-up, before game options are loaded.
+	 * 
+	 * <p>
+	 * Custom keybind registration should be done in a listener of this event.
+	 * Helper methods for registering keybinds can be found in the {@linkplain
+	 * KeybindRegistry} class.
+	 * 
+	 * <p>
+	 * Listeners to this event should be registered in your mod's entrypoint,
+	 * and can be done as follows:
+	 * 
+	 * <pre>
+	 * {@code
+	 * KeybindEvents.REGISTER_KEYBINDS.register(() -> {
+	 * 	KeybindRegistry.register("cookie", Keyboard.KEY_Z, "example");
+	 * });
+	 * }
+	 * </pre>
+	 * 
+	 * @see KeybindRegistry
+	 */
+	public static final Event<Runnable> REGISTER_KEYBINDS = Event.runnable();
+
+}

--- a/libraries/keybinds/keybinds-mc17w16a-mc1.12.2/src/main/java/net/ornithemc/osl/keybinds/api/KeybindRegistry.java
+++ b/libraries/keybinds/keybinds-mc17w16a-mc1.12.2/src/main/java/net/ornithemc/osl/keybinds/api/KeybindRegistry.java
@@ -1,0 +1,38 @@
+package net.ornithemc.osl.keybinds.api;
+
+import java.util.Set;
+
+import net.minecraft.client.options.KeyBinding;
+
+import net.ornithemc.osl.keybinds.impl.KeybindRegistryImpl;
+
+/**
+ * Public access to the Keybinds registry.
+ */
+public final class KeybindRegistry {
+
+	/**
+	 * @return the set of all keybind categories.
+	 */
+	public static Set<String> getCategories() {
+		return KeybindRegistryImpl.getCategories();
+	}
+
+	/**
+	 * @param name           the name or translation key of the keybind.
+	 * @param defaultKeyCode the default key code of the keybind.
+	 * @param category       the name or translation key of the category to which the keybind belongs.
+	 * @return the registered keybind.
+	 */
+	public static KeyBinding register(String name, int defaultKeyCode, String category) {
+		return KeybindRegistryImpl.register(name, defaultKeyCode, category);
+	}
+
+	/**
+	 * @param keybind the keybind to register.
+	 * @return the registered keybind.
+	 */
+	public static KeyBinding register(KeyBinding keybind) {
+		return KeybindRegistryImpl.register(keybind);
+	}
+}

--- a/libraries/keybinds/keybinds-mc17w16a-mc1.12.2/src/main/java/net/ornithemc/osl/keybinds/impl/KeybindRegistryImpl.java
+++ b/libraries/keybinds/keybinds-mc17w16a-mc1.12.2/src/main/java/net/ornithemc/osl/keybinds/impl/KeybindRegistryImpl.java
@@ -1,0 +1,83 @@
+package net.ornithemc.osl.keybinds.impl;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.commons.lang3.ArrayUtils;
+
+import net.minecraft.client.options.GameOptions;
+import net.minecraft.client.options.KeyBinding;
+
+import net.ornithemc.osl.keybinds.api.KeyBindingEvents;
+import net.ornithemc.osl.keybinds.api.KeyBindingRegistry;
+import net.ornithemc.osl.keybinds.api.KeybindEvents;
+import net.ornithemc.osl.keybinds.impl.mixin.client.KeyBindingAccessor;
+
+public final class KeybindRegistryImpl {
+
+	private static GameOptions options;
+	private static Set<String> categories;
+	private static Map<String, Integer> sortOrder;
+
+	private static List<KeyBinding> pendingKeybinds;
+
+	public static Set<String> getCategories() {
+		return categories;
+	}
+
+	public static KeyBinding register(String name, int defaultKeyCode, String category) {
+		return register(new KeyBinding(name, defaultKeyCode, category));
+	}
+
+	public static KeyBinding register(KeyBinding keybind) {
+		addCategory(keybind.getCategory());
+		addKeybind(keybind);
+
+		return keybind;
+	}
+
+	private static void addCategory(String category) {
+		categories.add(category);
+
+		if (!sortOrder.containsKey(category)) {
+			sortOrder.put(category, sortOrder.size() + 1);
+		}
+	}
+
+	private static void addKeybind(KeyBinding keybind) {
+		if (pendingKeybinds != null) {
+			pendingKeybinds.add(keybind);
+		} else {
+			// this code path is only reached if register methods are called after
+			// the event has been run - manually append the keybind anyway
+			options.keyBindings = ArrayUtils.addAll(options.keyBindings, keybind);
+		}
+	}
+
+	public static void init(GameOptions gameOptions) {
+		options = gameOptions;
+		categories = KeyBindingAccessor.accessCategories();
+		sortOrder = KeyBindingAccessor.accessCategorySortOrder();
+
+		pendingKeybinds = new ArrayList<>();
+
+		KeyBindingEvents.REGISTER_KEYBINDS.invoker().accept(new KeyBindingRegistry() {
+
+			@Override
+			public KeyBinding register(String name, int defaultKeyCode, String category) {
+				return KeybindRegistryImpl.register(name, defaultKeyCode, category);
+			}
+
+			@Override
+			public KeyBinding register(KeyBinding keybind) {
+				return KeybindRegistryImpl.register(keybind);
+			}
+		});
+		KeybindEvents.REGISTER_KEYBINDS.invoker().run();
+
+		options.keyBindings = ArrayUtils.addAll(options.keyBindings, pendingKeybinds.toArray(new KeyBinding[0]));
+		pendingKeybinds = null;
+	}
+}

--- a/libraries/keybinds/keybinds-mc17w16a-mc1.12.2/src/main/java/net/ornithemc/osl/keybinds/impl/mixin/client/GameOptionsMixin.java
+++ b/libraries/keybinds/keybinds-mc17w16a-mc1.12.2/src/main/java/net/ornithemc/osl/keybinds/impl/mixin/client/GameOptionsMixin.java
@@ -1,26 +1,16 @@
 package net.ornithemc.osl.keybinds.impl.mixin.client;
 
-import java.util.LinkedHashSet;
-import java.util.Map;
-import java.util.Set;
-
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 import net.minecraft.client.options.GameOptions;
-import net.minecraft.client.options.KeyBinding;
 
-import net.ornithemc.osl.keybinds.api.KeyBindingEvents;
-import net.ornithemc.osl.keybinds.api.KeyBindingRegistry;
+import net.ornithemc.osl.keybinds.impl.KeybindRegistryImpl;
 
 @Mixin(GameOptions.class)
-public class GameOptionsMixin implements KeyBindingRegistry {
-
-	@Shadow private KeyBinding[] keyBindings;
-	private Set<KeyBinding> modKeyBindings;
+public class GameOptionsMixin {
 
 	@Inject(
 		method = "<init>(Lnet/minecraft/client/Minecraft;Ljava/io/File;)V",
@@ -30,39 +20,6 @@ public class GameOptionsMixin implements KeyBindingRegistry {
 		)
 	)
 	private void osl$keybinds$registerKeybinds(CallbackInfo ci) {
-		modKeyBindings = new LinkedHashSet<>();
-
-		KeyBindingEvents.REGISTER_KEYBINDS.invoker().accept(this);
-
-		KeyBinding[] mcKeybinds = keyBindings;
-		keyBindings = new KeyBinding[mcKeybinds.length + modKeyBindings.size()];
-
-		int i = 0;
-		for (KeyBinding keybind : mcKeybinds) {
-			keyBindings[i++] = keybind;
-		}
-		for (KeyBinding keybind : modKeyBindings) {
-			keyBindings[i++] = keybind;
-		}
-	}
-
-	@Override
-	public KeyBinding register(String name, int defaultKeyCode, String category) {
-		return register(new KeyBinding(name, defaultKeyCode, category));
-	}
-
-	@Override
-	public KeyBinding register(KeyBinding keybind) {
-		modKeyBindings.add(keybind);
-		addCategory(keybind.getCategory());
-		return keybind;
-	}
-
-	private void addCategory(String category) {
-		Map<String, Integer> sortOrder = KeyBindingAccessor.osl$keybinds$getCategorySortOrder();
-
-		if (!sortOrder.containsKey(category)) {
-			sortOrder.put(category, sortOrder.size() + 1);
-		}
+		KeybindRegistryImpl.init((GameOptions) (Object) this);
 	}
 }

--- a/libraries/keybinds/keybinds-mc17w43a-mc1.14.4/src/main/java/net/ornithemc/osl/keybinds/api/KeyBindingEvents.java
+++ b/libraries/keybinds/keybinds-mc17w43a-mc1.14.4/src/main/java/net/ornithemc/osl/keybinds/api/KeyBindingEvents.java
@@ -6,7 +6,10 @@ import net.ornithemc.osl.core.api.events.Event;
 
 /**
  * Events related to Minecraft's keybinds.
+ * 
+ * @deprecated use {@linkplain KeybindEvents} instead
  */
+@Deprecated
 public class KeyBindingEvents {
 
 	/**

--- a/libraries/keybinds/keybinds-mc17w43a-mc1.14.4/src/main/java/net/ornithemc/osl/keybinds/api/KeybindEvents.java
+++ b/libraries/keybinds/keybinds-mc17w43a-mc1.14.4/src/main/java/net/ornithemc/osl/keybinds/api/KeybindEvents.java
@@ -1,0 +1,34 @@
+package net.ornithemc.osl.keybinds.api;
+
+import net.ornithemc.osl.core.api.events.Event;
+
+/**
+ * Events related to Minecraft's keybinds.
+ */
+public final class KeybindEvents {
+
+	/**
+	 * This event is invoked upon game start-up, before game options are loaded.
+	 * 
+	 * <p>
+	 * Custom keybind registration should be done in a listener of this event.
+	 * Helper methods for registering keybinds can be found in the {@linkplain
+	 * KeybindRegistry} class.
+	 * 
+	 * <p>
+	 * Listeners to this event should be registered in your mod's entrypoint,
+	 * and can be done as follows:
+	 * 
+	 * <pre>
+	 * {@code
+	 * KeybindEvents.REGISTER_KEYBINDS.register(() -> {
+	 * 	KeybindRegistry.register("cookie", GLFW.GLFW_KEY_Z, "example");
+	 * });
+	 * }
+	 * </pre>
+	 * 
+	 * @see KeybindRegistry
+	 */
+	public static final Event<Runnable> REGISTER_KEYBINDS = Event.runnable();
+
+}

--- a/libraries/keybinds/keybinds-mc17w43a-mc1.14.4/src/main/java/net/ornithemc/osl/keybinds/api/KeybindRegistry.java
+++ b/libraries/keybinds/keybinds-mc17w43a-mc1.14.4/src/main/java/net/ornithemc/osl/keybinds/api/KeybindRegistry.java
@@ -1,0 +1,51 @@
+package net.ornithemc.osl.keybinds.api;
+
+import java.util.Set;
+
+import com.mojang.blaze3d.platform.InputConstants;
+
+import net.minecraft.client.options.KeyBinding;
+
+import net.ornithemc.osl.keybinds.impl.KeybindRegistryImpl;
+
+/**
+ * Public access to the Keybinds registry.
+ */
+public final class KeybindRegistry {
+
+	/**
+	 * @return the set of all keybind categories.
+	 */
+	public static Set<String> getCategories() {
+		return KeybindRegistryImpl.getCategories();
+	}
+
+	/**
+	 * @param name           the name or translation key of the keybind.
+	 * @param defaultKeyCode the default key code of the keybind.
+	 * @param category       the name or translation key of the category to which the keybind belongs.
+	 * @return the registered keybind.
+	 */
+	public static KeyBinding register(String name, int defaultKeyCode, String category) {
+		return KeybindRegistryImpl.register(name, defaultKeyCode, category);
+	}
+
+	/**
+	 * @param name           the name or translation key of the keybind.
+	 * @param type           the type of input allowed for the default key code.
+	 * @param defaultKeyCode the default key code of the keybind.
+	 * @param category       the name or translation key of the category to which the keybind belongs.
+	 * @return the registered keybind.
+	 */
+	public static KeyBinding register(String name, InputConstants.Type type, int defaultKeyCode, String category) {
+		return KeybindRegistryImpl.register(name, type, defaultKeyCode, category);
+	}
+
+	/**
+	 * @param keybind the keybind to register.
+	 * @return the registered keybind.
+	 */
+	public static KeyBinding register(KeyBinding keybind) {
+		return KeybindRegistryImpl.register(keybind);
+	}
+}

--- a/libraries/keybinds/keybinds-mc17w43a-mc1.14.4/src/main/java/net/ornithemc/osl/keybinds/impl/KeybindRegistryImpl.java
+++ b/libraries/keybinds/keybinds-mc17w43a-mc1.14.4/src/main/java/net/ornithemc/osl/keybinds/impl/KeybindRegistryImpl.java
@@ -1,0 +1,95 @@
+package net.ornithemc.osl.keybinds.impl;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.commons.lang3.ArrayUtils;
+
+import com.mojang.blaze3d.platform.InputConstants;
+import com.mojang.blaze3d.platform.InputConstants.Type;
+
+import net.minecraft.client.options.GameOptions;
+import net.minecraft.client.options.KeyBinding;
+
+import net.ornithemc.osl.keybinds.api.KeyBindingEvents;
+import net.ornithemc.osl.keybinds.api.KeyBindingRegistry;
+import net.ornithemc.osl.keybinds.api.KeybindEvents;
+import net.ornithemc.osl.keybinds.impl.mixin.client.KeyBindingAccessor;
+
+public final class KeybindRegistryImpl {
+
+	private static GameOptions options;
+	private static Set<String> categories;
+	private static Map<String, Integer> sortOrder;
+
+	private static List<KeyBinding> pendingKeybinds;
+
+	public static Set<String> getCategories() {
+		return categories;
+	}
+
+	public static KeyBinding register(String name, int defaultKeyCode, String category) {
+		return register(new KeyBinding(name, defaultKeyCode, category));
+	}
+
+	public static KeyBinding register(String name, InputConstants.Type type, int defaultKeyCode, String category) {
+		return register(new KeyBinding(name, type, defaultKeyCode, category));
+	}
+
+	public static KeyBinding register(KeyBinding keybind) {
+		addCategory(keybind.getCategory());
+		addKeybind(keybind);
+
+		return keybind;
+	}
+
+	private static void addCategory(String category) {
+		categories.add(category);
+
+		if (!sortOrder.containsKey(category)) {
+			sortOrder.put(category, sortOrder.size() + 1);
+		}
+	}
+
+	private static void addKeybind(KeyBinding keybind) {
+		if (pendingKeybinds != null) {
+			pendingKeybinds.add(keybind);
+		} else {
+			// this code path is only reached if register methods are called after
+			// the event has been run - manually append the keybind anyway
+			options.keyBindings = ArrayUtils.addAll(options.keyBindings, keybind);
+		}
+	}
+
+	public static void init(GameOptions gameOptions) {
+		options = gameOptions;
+		categories = KeyBindingAccessor.accessCategories();
+		sortOrder = KeyBindingAccessor.accessCategorySortOrder();
+
+		pendingKeybinds = new ArrayList<>();
+
+		KeyBindingEvents.REGISTER_KEYBINDS.invoker().accept(new KeyBindingRegistry() {
+
+			@Override
+			public KeyBinding register(String name, int defaultKeyCode, String category) {
+				return KeybindRegistryImpl.register(name, defaultKeyCode, category);
+			}
+
+			@Override
+			public KeyBinding register(String name, Type type, int defaultKeyCode, String category) {
+				return KeybindRegistryImpl.register(name, type, defaultKeyCode, category);
+			}
+
+			@Override
+			public KeyBinding register(KeyBinding keybind) {
+				return KeybindRegistryImpl.register(keybind);
+			}
+		});
+		KeybindEvents.REGISTER_KEYBINDS.invoker().run();
+
+		options.keyBindings = ArrayUtils.addAll(options.keyBindings, pendingKeybinds.toArray(new KeyBinding[0]));
+		pendingKeybinds = null;
+	}
+}

--- a/libraries/keybinds/keybinds-mc17w43a-mc1.14.4/src/main/java/net/ornithemc/osl/keybinds/impl/mixin/client/GameOptionsMixin.java
+++ b/libraries/keybinds/keybinds-mc17w43a-mc1.14.4/src/main/java/net/ornithemc/osl/keybinds/impl/mixin/client/GameOptionsMixin.java
@@ -1,28 +1,16 @@
 package net.ornithemc.osl.keybinds.impl.mixin.client;
 
-import java.util.LinkedHashSet;
-import java.util.Map;
-import java.util.Set;
-
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
-import com.mojang.blaze3d.platform.InputConstants.Type;
-
 import net.minecraft.client.options.GameOptions;
-import net.minecraft.client.options.KeyBinding;
 
-import net.ornithemc.osl.keybinds.api.KeyBindingEvents;
-import net.ornithemc.osl.keybinds.api.KeyBindingRegistry;
+import net.ornithemc.osl.keybinds.impl.KeybindRegistryImpl;
 
 @Mixin(GameOptions.class)
-public class GameOptionsMixin implements KeyBindingRegistry {
-
-	@Shadow private KeyBinding[] keyBindings;
-	private Set<KeyBinding> modKeyBindings;
+public class GameOptionsMixin {
 
 	@Inject(
 		method = "<init>(Lnet/minecraft/client/Minecraft;Ljava/io/File;)V",
@@ -32,44 +20,6 @@ public class GameOptionsMixin implements KeyBindingRegistry {
 		)
 	)
 	private void osl$keybinds$registerKeybinds(CallbackInfo ci) {
-		modKeyBindings = new LinkedHashSet<>();
-
-		KeyBindingEvents.REGISTER_KEYBINDS.invoker().accept(this);
-
-		KeyBinding[] mcKeybinds = keyBindings;
-		keyBindings = new KeyBinding[mcKeybinds.length + modKeyBindings.size()];
-
-		int i = 0;
-		for (KeyBinding keybind : mcKeybinds) {
-			keyBindings[i++] = keybind;
-		}
-		for (KeyBinding keybind : modKeyBindings) {
-			keyBindings[i++] = keybind;
-		}
-	}
-
-	@Override
-	public KeyBinding register(String name, int defaultKeyCode, String category) {
-		return register(new KeyBinding(name, defaultKeyCode, category));
-	}
-
-	@Override
-	public KeyBinding register(String name, Type type, int defaultKeyCode, String category) {
-		return register(new KeyBinding(name, type, defaultKeyCode, category));
-	}
-
-	@Override
-	public KeyBinding register(KeyBinding keybind) {
-		modKeyBindings.add(keybind);
-		addCategory(keybind.getCategory());
-		return keybind;
-	}
-
-	private void addCategory(String category) {
-		Map<String, Integer> sortOrder = KeyBindingAccessor.osl$keybinds$getCategorySortOrder();
-
-		if (!sortOrder.containsKey(category)) {
-			sortOrder.put(category, sortOrder.size() + 1);
-		}
+		KeybindRegistryImpl.init((GameOptions) (Object) this);
 	}
 }

--- a/libraries/keybinds/keybinds-mc17w43a-mc1.14.4/src/main/java/net/ornithemc/osl/keybinds/impl/mixin/client/KeyBindingAccessor.java
+++ b/libraries/keybinds/keybinds-mc17w43a-mc1.14.4/src/main/java/net/ornithemc/osl/keybinds/impl/mixin/client/KeyBindingAccessor.java
@@ -1,6 +1,7 @@
 package net.ornithemc.osl.keybinds.impl.mixin.client;
 
 import java.util.Map;
+import java.util.Set;
 
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.gen.Accessor;
@@ -10,8 +11,13 @@ import net.minecraft.client.options.KeyBinding;
 @Mixin(KeyBinding.class)
 public interface KeyBindingAccessor {
 
+	@Accessor("CATEGORIES")
+	static Set<String> accessCategories() {
+		throw new UnsupportedOperationException();
+	}
+
 	@Accessor("CATEGORY_SORT_ORDER")
-	static Map<String, Integer> osl$keybinds$getCategorySortOrder() {
+	static Map<String, Integer> accessCategorySortOrder() {
 		throw new UnsupportedOperationException();
 	}
 }

--- a/libraries/keybinds/keybinds-mc17w43a-mc1.14.4/src/main/resources/fabric.mod.json
+++ b/libraries/keybinds/keybinds-mc17w43a-mc1.14.4/src/main/resources/fabric.mod.json
@@ -6,6 +6,7 @@
   "mixins": [
     "osl.keybinds.mixins.json"
   ],
+  "accessWidener": "osl.keybinds.classtweaker",
   "depends": {
     "fabricloader": "\u003e\u003d0.18.0",
     "minecraft": "\u003e\u003d1.13-alpha.17.43.a \u003c\u003d1.14.4",

--- a/libraries/keybinds/keybinds-mc17w43a-mc1.14.4/src/main/resources/osl.keybinds.classtweaker
+++ b/libraries/keybinds/keybinds-mc17w43a-mc1.14.4/src/main/resources/osl.keybinds.classtweaker
@@ -1,0 +1,3 @@
+classTweaker	v1	named
+
+mutable	field	net/minecraft/client/options/GameOptions	keyBindings	[Lnet/minecraft/client/options/KeyBinding;

--- a/libraries/keybinds/keybinds-mcb1.8-pre1-mc1.6.4/src/main/java/net/ornithemc/osl/keybinds/api/KeyBindingEvents.java
+++ b/libraries/keybinds/keybinds-mcb1.8-pre1-mc1.6.4/src/main/java/net/ornithemc/osl/keybinds/api/KeyBindingEvents.java
@@ -6,7 +6,10 @@ import net.ornithemc.osl.core.api.events.Event;
 
 /**
  * Events related to Minecraft's keybinds.
+ * 
+ * @deprecated use {@linkplain KeybindEvents} instead
  */
+@Deprecated
 public class KeyBindingEvents {
 
 	/**

--- a/libraries/keybinds/keybinds-mcb1.8-pre1-mc1.6.4/src/main/java/net/ornithemc/osl/keybinds/api/KeybindEvents.java
+++ b/libraries/keybinds/keybinds-mcb1.8-pre1-mc1.6.4/src/main/java/net/ornithemc/osl/keybinds/api/KeybindEvents.java
@@ -1,0 +1,34 @@
+package net.ornithemc.osl.keybinds.api;
+
+import net.ornithemc.osl.core.api.events.Event;
+
+/**
+ * Events related to Minecraft's keybinds.
+ */
+public final class KeybindEvents {
+
+	/**
+	 * This event is invoked upon game start-up, before game options are loaded.
+	 * 
+	 * <p>
+	 * Custom keybind registration should be done in a listener of this event.
+	 * Helper methods for registering keybinds can be found in the {@linkplain
+	 * KeybindRegistry} class.
+	 * 
+	 * <p>
+	 * Listeners to this event should be registered in your mod's entrypoint,
+	 * and can be done as follows:
+	 * 
+	 * <pre>
+	 * {@code
+	 * KeybindEvents.REGISTER_KEYBINDS.register(() -> {
+	 * 	KeybindRegistry.register("cookie", Keyboard.KEY_Z, "example");
+	 * });
+	 * }
+	 * </pre>
+	 * 
+	 * @see KeybindRegistry
+	 */
+	public static final Event<Runnable> REGISTER_KEYBINDS = Event.runnable();
+
+}

--- a/libraries/keybinds/keybinds-mcb1.8-pre1-mc1.6.4/src/main/java/net/ornithemc/osl/keybinds/api/KeybindRegistry.java
+++ b/libraries/keybinds/keybinds-mcb1.8-pre1-mc1.6.4/src/main/java/net/ornithemc/osl/keybinds/api/KeybindRegistry.java
@@ -1,0 +1,39 @@
+package net.ornithemc.osl.keybinds.api;
+
+import java.util.Set;
+
+import net.minecraft.client.options.KeyBinding;
+
+import net.ornithemc.osl.keybinds.impl.KeybindRegistryImpl;
+
+/**
+ * Public access to the Keybinds registry.
+ */
+public final class KeybindRegistry {
+
+	/**
+	 * @return the set of all keybind categories.
+	 */
+	public static Set<String> getCategories() {
+		return KeybindRegistryImpl.getCategories();
+	}
+
+	/**
+	 * @param name           the name or translation key of the keybind.
+	 * @param defaultKeyCode the default key code of the keybind.
+	 * @param category       the name or translation key of the category to which the keybind belongs.
+	 * @return the registered keybind.
+	 */
+	public static KeyBinding register(String name, int defaultKeyCode, String category) {
+		return KeybindRegistryImpl.register(name, defaultKeyCode, category);
+	}
+
+	/**
+	 * @param keybind the keybind to register.
+	 * @param category       the name or translation key of the category to which the keybind belongs.
+	 * @return the registered keybind.
+	 */
+	public static KeyBinding register(KeyBinding keybind, String category) {
+		return KeybindRegistryImpl.register(keybind, category);
+	}
+}

--- a/libraries/keybinds/keybinds-mcb1.8-pre1-mc1.6.4/src/main/java/net/ornithemc/osl/keybinds/api/keybind/KeyBindingExtension.java
+++ b/libraries/keybinds/keybinds-mcb1.8-pre1-mc1.6.4/src/main/java/net/ornithemc/osl/keybinds/api/keybind/KeyBindingExtension.java
@@ -1,0 +1,7 @@
+package net.ornithemc.osl.keybinds.api.keybind;
+
+public interface KeyBindingExtension {
+
+	String getCategory();
+
+}

--- a/libraries/keybinds/keybinds-mcb1.8-pre1-mc1.6.4/src/main/java/net/ornithemc/osl/keybinds/impl/KeybindRegistryImpl.java
+++ b/libraries/keybinds/keybinds-mcb1.8-pre1-mc1.6.4/src/main/java/net/ornithemc/osl/keybinds/impl/KeybindRegistryImpl.java
@@ -1,0 +1,87 @@
+package net.ornithemc.osl.keybinds.impl;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.apache.commons.lang3.ArrayUtils;
+
+import net.minecraft.client.options.GameOptions;
+import net.minecraft.client.options.KeyBinding;
+
+import net.ornithemc.osl.keybinds.api.KeyBindingEvents;
+import net.ornithemc.osl.keybinds.api.KeyBindingRegistry;
+import net.ornithemc.osl.keybinds.api.KeybindEvents;
+import net.ornithemc.osl.keybinds.impl.access.KeyBindingAccess;
+
+public final class KeybindRegistryImpl {
+
+	private static GameOptions options;
+	private static Set<String> categories;
+
+	private static List<KeyBinding> pendingKeybinds;
+
+	public static Set<String> getCategories() {
+		return categories;
+	}
+
+	public static KeyBinding register(String name, int defaultKeyCode, String category) {
+		return register(new KeyBinding(name, defaultKeyCode), category);
+	}
+
+	public static KeyBinding register(KeyBinding keybind, String category) {
+		addCategory(category);
+		addKeybind(keybind);
+
+		if (category != null) {
+			((KeyBindingAccess) keybind).osl$keybinds$setCategory(category);
+		}
+
+		return keybind;
+	}
+
+	private static void addCategory(String category) {
+		categories.add(category);
+	}
+
+	private static void addKeybind(KeyBinding keybind) {
+		if (pendingKeybinds != null) {
+			pendingKeybinds.add(keybind);
+		} else {
+			// this code path is only reached if register methods are called after
+			// the event has been run - manually append the keybind anyway
+			options.keyBindings = ArrayUtils.addAll(options.keyBindings, keybind);
+		}
+	}
+
+	public static void init(GameOptions gameOptions) {
+		options = gameOptions;
+		categories = new HashSet<>();
+
+		pendingKeybinds = new ArrayList<>();
+
+		// TODO: properly categorize Vanilla keybinds
+		// TODO: use translation key
+		for (KeyBinding keybind : options.keyBindings) {
+			((KeyBindingAccess) keybind).osl$keybinds$setCategory("Vanilla");
+		}
+
+		KeyBindingEvents.REGISTER_KEYBINDS.invoker().accept(new KeyBindingRegistry() {
+
+			@Override
+			public KeyBinding register(String name, int defaultKeyCode) {
+				return KeybindRegistryImpl.register(name, defaultKeyCode, null);
+			}
+
+			@Override
+			public KeyBinding register(KeyBinding keybind) {
+				return KeybindRegistryImpl.register(keybind, null);
+			}
+		});
+		KeybindEvents.REGISTER_KEYBINDS.invoker().run();
+
+		options.keyBindings = ArrayUtils.addAll(options.keyBindings, pendingKeybinds.toArray(new KeyBinding[0]));
+		pendingKeybinds = null;
+	}
+}

--- a/libraries/keybinds/keybinds-mcb1.8-pre1-mc1.6.4/src/main/java/net/ornithemc/osl/keybinds/impl/access/KeyBindingAccess.java
+++ b/libraries/keybinds/keybinds-mcb1.8-pre1-mc1.6.4/src/main/java/net/ornithemc/osl/keybinds/impl/access/KeyBindingAccess.java
@@ -1,0 +1,7 @@
+package net.ornithemc.osl.keybinds.impl.access;
+
+public interface KeyBindingAccess {
+
+	void osl$keybinds$setCategory(String category);
+
+}

--- a/libraries/keybinds/keybinds-mcb1.8-pre1-mc1.6.4/src/main/java/net/ornithemc/osl/keybinds/impl/keybind/KeyBindingExtensionImpl.java
+++ b/libraries/keybinds/keybinds-mcb1.8-pre1-mc1.6.4/src/main/java/net/ornithemc/osl/keybinds/impl/keybind/KeyBindingExtensionImpl.java
@@ -1,0 +1,11 @@
+package net.ornithemc.osl.keybinds.impl.keybind;
+
+import net.ornithemc.osl.keybinds.api.keybind.KeyBindingExtension;
+
+public interface KeyBindingExtensionImpl extends KeyBindingExtension {
+
+	@Override
+	default String getCategory() {
+		throw new AbstractMethodError();
+	}
+}

--- a/libraries/keybinds/keybinds-mcb1.8-pre1-mc1.6.4/src/main/java/net/ornithemc/osl/keybinds/impl/mixin/client/GameOptionsMixin.java
+++ b/libraries/keybinds/keybinds-mcb1.8-pre1-mc1.6.4/src/main/java/net/ornithemc/osl/keybinds/impl/mixin/client/GameOptionsMixin.java
@@ -1,25 +1,16 @@
 package net.ornithemc.osl.keybinds.impl.mixin.client;
 
-import java.util.LinkedHashSet;
-import java.util.Set;
-
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 import net.minecraft.client.options.GameOptions;
-import net.minecraft.client.options.KeyBinding;
 
-import net.ornithemc.osl.keybinds.api.KeyBindingEvents;
-import net.ornithemc.osl.keybinds.api.KeyBindingRegistry;
+import net.ornithemc.osl.keybinds.impl.KeybindRegistryImpl;
 
 @Mixin(GameOptions.class)
-public class GameOptionsMixin implements KeyBindingRegistry {
-
-	@Shadow private KeyBinding[] keyBindings;
-	private Set<KeyBinding> modKeyBindings;
+public class GameOptionsMixin {
 
 	@Inject(
 		method = "<init>(Lnet/minecraft/client/Minecraft;Ljava/io/File;)V",
@@ -29,30 +20,6 @@ public class GameOptionsMixin implements KeyBindingRegistry {
 		)
 	)
 	private void osl$keybinds$registerKeybinds(CallbackInfo ci) {
-		modKeyBindings = new LinkedHashSet<>();
-
-		KeyBindingEvents.REGISTER_KEYBINDS.invoker().accept(this);
-
-		KeyBinding[] mcKeybinds = keyBindings;
-		keyBindings = new KeyBinding[mcKeybinds.length + modKeyBindings.size()];
-
-		int i = 0;
-		for (KeyBinding keybind : mcKeybinds) {
-			keyBindings[i++] = keybind;
-		}
-		for (KeyBinding keybind : modKeyBindings) {
-			keyBindings[i++] = keybind;
-		}
-	}
-
-	@Override
-	public KeyBinding register(String name, int defaultKeyCode) {
-		return register(new KeyBinding(name, defaultKeyCode));
-	}
-
-	@Override
-	public KeyBinding register(KeyBinding keybind) {
-		modKeyBindings.add(keybind);
-		return keybind;
+		KeybindRegistryImpl.init((GameOptions) (Object) this);
 	}
 }

--- a/libraries/keybinds/keybinds-mcb1.8-pre1-mc1.6.4/src/main/java/net/ornithemc/osl/keybinds/impl/mixin/client/KeyBindingMixin.java
+++ b/libraries/keybinds/keybinds-mcb1.8-pre1-mc1.6.4/src/main/java/net/ornithemc/osl/keybinds/impl/mixin/client/KeyBindingMixin.java
@@ -1,0 +1,26 @@
+package net.ornithemc.osl.keybinds.impl.mixin.client;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+
+import net.minecraft.client.options.KeyBinding;
+
+import net.ornithemc.osl.keybinds.api.keybind.KeyBindingExtension;
+import net.ornithemc.osl.keybinds.impl.access.KeyBindingAccess;
+
+@Mixin(KeyBinding.class)
+public class KeyBindingMixin implements KeyBindingExtension, KeyBindingAccess {
+
+	@Unique
+	private String category = "None";
+
+	@Override
+	public String getCategory() {
+		return this.category;
+	}
+
+	@Override
+	public void osl$keybinds$setCategory(String category) {
+		this.category = category;
+	}
+}

--- a/libraries/keybinds/keybinds-mcb1.8-pre1-mc1.6.4/src/main/resources/fabric.mod.json
+++ b/libraries/keybinds/keybinds-mcb1.8-pre1-mc1.6.4/src/main/resources/fabric.mod.json
@@ -6,6 +6,7 @@
   "mixins": [
     "osl.keybinds.mixins.json"
   ],
+  "accessWidener": "osl.keybinds.classtweaker",
   "depends": {
     "fabricloader": "\u003e\u003d0.18.0",
     "minecraft": "\u003e\u003d1.0.0-beta.8 \u003c\u003d1.6.4",

--- a/libraries/keybinds/keybinds-mcb1.8-pre1-mc1.6.4/src/main/resources/osl.keybinds.classtweaker
+++ b/libraries/keybinds/keybinds-mcb1.8-pre1-mc1.6.4/src/main/resources/osl.keybinds.classtweaker
@@ -1,0 +1,3 @@
+classTweaker	v1	named
+
+transitive-inject-interface	net/minecraft/client/options/KeyBinding	net/ornithemc/osl/keybinds/impl/keybind/KeyBindingExtensionImpl

--- a/libraries/keybinds/keybinds-mcb1.8-pre1-mc1.6.4/src/main/resources/osl.keybinds.mixins.json
+++ b/libraries/keybinds/keybinds-mcb1.8-pre1-mc1.6.4/src/main/resources/osl.keybinds.mixins.json
@@ -6,7 +6,8 @@
 	"mixins": [
 	],
 	"client": [
-		"client.GameOptionsMixin"
+		"client.GameOptionsMixin",
+		"client.KeyBindingMixin"
 	],
 	"server": [
 	],

--- a/libraries/keybinds/keybinds-mcc0.0.23a_01-mcb1.7.3/src/main/java/net/ornithemc/osl/keybinds/api/KeyBindingEvents.java
+++ b/libraries/keybinds/keybinds-mcc0.0.23a_01-mcb1.7.3/src/main/java/net/ornithemc/osl/keybinds/api/KeyBindingEvents.java
@@ -6,7 +6,10 @@ import net.ornithemc.osl.core.api.events.Event;
 
 /**
  * Events related to Minecraft's keybinds.
+ * 
+ * @deprecated use {@linkplain KeybindEvents} instead
  */
+@Deprecated
 public class KeyBindingEvents {
 
 	/**

--- a/libraries/keybinds/keybinds-mcc0.0.23a_01-mcb1.7.3/src/main/java/net/ornithemc/osl/keybinds/api/KeybindEvents.java
+++ b/libraries/keybinds/keybinds-mcc0.0.23a_01-mcb1.7.3/src/main/java/net/ornithemc/osl/keybinds/api/KeybindEvents.java
@@ -1,0 +1,34 @@
+package net.ornithemc.osl.keybinds.api;
+
+import net.ornithemc.osl.core.api.events.Event;
+
+/**
+ * Events related to Minecraft's keybinds.
+ */
+public final class KeybindEvents {
+
+	/**
+	 * This event is invoked upon game start-up, before game options are loaded.
+	 * 
+	 * <p>
+	 * Custom keybind registration should be done in a listener of this event.
+	 * Helper methods for registering keybinds can be found in the {@linkplain
+	 * KeybindRegistry} class.
+	 * 
+	 * <p>
+	 * Listeners to this event should be registered in your mod's entrypoint,
+	 * and can be done as follows:
+	 * 
+	 * <pre>
+	 * {@code
+	 * KeybindEvents.REGISTER_KEYBINDS.register(() -> {
+	 * 	KeybindRegistry.register("cookie", Keyboard.KEY_Z, "example");
+	 * });
+	 * }
+	 * </pre>
+	 * 
+	 * @see KeybindRegistry
+	 */
+	public static final Event<Runnable> REGISTER_KEYBINDS = Event.runnable();
+
+}

--- a/libraries/keybinds/keybinds-mcc0.0.23a_01-mcb1.7.3/src/main/java/net/ornithemc/osl/keybinds/api/KeybindRegistry.java
+++ b/libraries/keybinds/keybinds-mcc0.0.23a_01-mcb1.7.3/src/main/java/net/ornithemc/osl/keybinds/api/KeybindRegistry.java
@@ -1,0 +1,39 @@
+package net.ornithemc.osl.keybinds.api;
+
+import java.util.Set;
+
+import net.minecraft.client.options.KeyBinding;
+
+import net.ornithemc.osl.keybinds.impl.KeybindRegistryImpl;
+
+/**
+ * Public access to the Keybinds registry.
+ */
+public final class KeybindRegistry {
+
+	/**
+	 * @return the set of all keybind categories.
+	 */
+	public static Set<String> getCategories() {
+		return KeybindRegistryImpl.getCategories();
+	}
+
+	/**
+	 * @param name           the name or translation key of the keybind.
+	 * @param defaultKeyCode the default key code of the keybind.
+	 * @param category       the name or translation key of the category to which the keybind belongs.
+	 * @return the registered keybind.
+	 */
+	public static KeyBinding register(String name, int defaultKeyCode, String category) {
+		return KeybindRegistryImpl.register(name, defaultKeyCode, category);
+	}
+
+	/**
+	 * @param keybind the keybind to register.
+	 * @param category       the name or translation key of the category to which the keybind belongs.
+	 * @return the registered keybind.
+	 */
+	public static KeyBinding register(KeyBinding keybind, String category) {
+		return KeybindRegistryImpl.register(keybind, category);
+	}
+}

--- a/libraries/keybinds/keybinds-mcc0.0.23a_01-mcb1.7.3/src/main/java/net/ornithemc/osl/keybinds/api/keybind/KeyBindingExtension.java
+++ b/libraries/keybinds/keybinds-mcc0.0.23a_01-mcb1.7.3/src/main/java/net/ornithemc/osl/keybinds/api/keybind/KeyBindingExtension.java
@@ -1,0 +1,7 @@
+package net.ornithemc.osl.keybinds.api.keybind;
+
+public interface KeyBindingExtension {
+
+	String getCategory();
+
+}

--- a/libraries/keybinds/keybinds-mcc0.0.23a_01-mcb1.7.3/src/main/java/net/ornithemc/osl/keybinds/impl/KeybindRegistryImpl.java
+++ b/libraries/keybinds/keybinds-mcc0.0.23a_01-mcb1.7.3/src/main/java/net/ornithemc/osl/keybinds/impl/KeybindRegistryImpl.java
@@ -1,0 +1,87 @@
+package net.ornithemc.osl.keybinds.impl;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.apache.commons.lang3.ArrayUtils;
+
+import net.minecraft.client.options.GameOptions;
+import net.minecraft.client.options.KeyBinding;
+
+import net.ornithemc.osl.keybinds.api.KeyBindingEvents;
+import net.ornithemc.osl.keybinds.api.KeyBindingRegistry;
+import net.ornithemc.osl.keybinds.api.KeybindEvents;
+import net.ornithemc.osl.keybinds.impl.access.KeyBindingAccess;
+
+public final class KeybindRegistryImpl {
+
+	private static GameOptions options;
+	private static Set<String> categories;
+
+	private static List<KeyBinding> pendingKeybinds;
+
+	public static Set<String> getCategories() {
+		return categories;
+	}
+
+	public static KeyBinding register(String name, int defaultKeyCode, String category) {
+		return register(new KeyBinding(name, defaultKeyCode), category);
+	}
+
+	public static KeyBinding register(KeyBinding keybind, String category) {
+		addCategory(category);
+		addKeybind(keybind);
+
+		if (category != null) {
+			((KeyBindingAccess) keybind).osl$keybinds$setCategory(category);
+		}
+
+		return keybind;
+	}
+
+	private static void addCategory(String category) {
+		categories.add(category);
+	}
+
+	private static void addKeybind(KeyBinding keybind) {
+		if (pendingKeybinds != null) {
+			pendingKeybinds.add(keybind);
+		} else {
+			// this code path is only reached if register methods are called after
+			// the event has been run - manually append the keybind anyway
+			options.keyBindings = ArrayUtils.addAll(options.keyBindings, keybind);
+		}
+	}
+
+	public static void init(GameOptions gameOptions) {
+		options = gameOptions;
+		categories = new HashSet<>();
+
+		pendingKeybinds = new ArrayList<>();
+
+		// TODO: properly categorize Vanilla keybinds
+		// TODO: use translation key
+		for (KeyBinding keybind : options.keyBindings) {
+			((KeyBindingAccess) keybind).osl$keybinds$setCategory("Vanilla");
+		}
+
+		KeyBindingEvents.REGISTER_KEYBINDS.invoker().accept(new KeyBindingRegistry() {
+
+			@Override
+			public KeyBinding register(String name, int defaultKeyCode) {
+				return KeybindRegistryImpl.register(name, defaultKeyCode, null);
+			}
+
+			@Override
+			public KeyBinding register(KeyBinding keybind) {
+				return KeybindRegistryImpl.register(keybind, null);
+			}
+		});
+		KeybindEvents.REGISTER_KEYBINDS.invoker().run();
+
+		options.keyBindings = ArrayUtils.addAll(options.keyBindings, pendingKeybinds.toArray(new KeyBinding[0]));
+		pendingKeybinds = null;
+	}
+}

--- a/libraries/keybinds/keybinds-mcc0.0.23a_01-mcb1.7.3/src/main/java/net/ornithemc/osl/keybinds/impl/access/KeyBindingAccess.java
+++ b/libraries/keybinds/keybinds-mcc0.0.23a_01-mcb1.7.3/src/main/java/net/ornithemc/osl/keybinds/impl/access/KeyBindingAccess.java
@@ -1,0 +1,7 @@
+package net.ornithemc.osl.keybinds.impl.access;
+
+public interface KeyBindingAccess {
+
+	void osl$keybinds$setCategory(String category);
+
+}

--- a/libraries/keybinds/keybinds-mcc0.0.23a_01-mcb1.7.3/src/main/java/net/ornithemc/osl/keybinds/impl/keybind/KeyBindingExtensionImpl.java
+++ b/libraries/keybinds/keybinds-mcc0.0.23a_01-mcb1.7.3/src/main/java/net/ornithemc/osl/keybinds/impl/keybind/KeyBindingExtensionImpl.java
@@ -1,0 +1,11 @@
+package net.ornithemc.osl.keybinds.impl.keybind;
+
+import net.ornithemc.osl.keybinds.api.keybind.KeyBindingExtension;
+
+public interface KeyBindingExtensionImpl extends KeyBindingExtension {
+
+	@Override
+	default String getCategory() {
+		throw new AbstractMethodError();
+	}
+}

--- a/libraries/keybinds/keybinds-mcc0.0.23a_01-mcb1.7.3/src/main/java/net/ornithemc/osl/keybinds/impl/mixin/client/GameOptionsMixin.java
+++ b/libraries/keybinds/keybinds-mcc0.0.23a_01-mcb1.7.3/src/main/java/net/ornithemc/osl/keybinds/impl/mixin/client/GameOptionsMixin.java
@@ -1,25 +1,16 @@
 package net.ornithemc.osl.keybinds.impl.mixin.client;
 
-import java.util.LinkedHashSet;
-import java.util.Set;
-
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 import net.minecraft.client.options.GameOptions;
-import net.minecraft.client.options.KeyBinding;
 
-import net.ornithemc.osl.keybinds.api.KeyBindingEvents;
-import net.ornithemc.osl.keybinds.api.KeyBindingRegistry;
+import net.ornithemc.osl.keybinds.impl.KeybindRegistryImpl;
 
 @Mixin(GameOptions.class)
-public class GameOptionsMixin implements KeyBindingRegistry {
-
-	@Shadow private KeyBinding[] keyBindings;
-	private Set<KeyBinding> modKeyBindings;
+public class GameOptionsMixin {
 
 	@Inject(
 		method = "<init>(Lnet/minecraft/client/Minecraft;Ljava/io/File;)V",
@@ -29,30 +20,6 @@ public class GameOptionsMixin implements KeyBindingRegistry {
 		)
 	)
 	private void osl$keybinds$registerKeybinds(CallbackInfo ci) {
-		modKeyBindings = new LinkedHashSet<>();
-
-		KeyBindingEvents.REGISTER_KEYBINDS.invoker().accept(this);
-
-		KeyBinding[] mcKeybinds = keyBindings;
-		keyBindings = new KeyBinding[mcKeybinds.length + modKeyBindings.size()];
-
-		int i = 0;
-		for (KeyBinding keybind : mcKeybinds) {
-			keyBindings[i++] = keybind;
-		}
-		for (KeyBinding keybind : modKeyBindings) {
-			keyBindings[i++] = keybind;
-		}
-	}
-
-	@Override
-	public KeyBinding register(String name, int defaultKeyCode) {
-		return register(new KeyBinding(name, defaultKeyCode));
-	}
-
-	@Override
-	public KeyBinding register(KeyBinding keybind) {
-		modKeyBindings.add(keybind);
-		return keybind;
+		KeybindRegistryImpl.init((GameOptions) (Object) this);
 	}
 }

--- a/libraries/keybinds/keybinds-mcc0.0.23a_01-mcb1.7.3/src/main/java/net/ornithemc/osl/keybinds/impl/mixin/client/KeyBindingMixin.java
+++ b/libraries/keybinds/keybinds-mcc0.0.23a_01-mcb1.7.3/src/main/java/net/ornithemc/osl/keybinds/impl/mixin/client/KeyBindingMixin.java
@@ -1,0 +1,26 @@
+package net.ornithemc.osl.keybinds.impl.mixin.client;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+
+import net.minecraft.client.options.KeyBinding;
+
+import net.ornithemc.osl.keybinds.api.keybind.KeyBindingExtension;
+import net.ornithemc.osl.keybinds.impl.access.KeyBindingAccess;
+
+@Mixin(KeyBinding.class)
+public class KeyBindingMixin implements KeyBindingExtension, KeyBindingAccess {
+
+	@Unique
+	private String category = "None";
+
+	@Override
+	public String getCategory() {
+		return this.category;
+	}
+
+	@Override
+	public void osl$keybinds$setCategory(String category) {
+		this.category = category;
+	}
+}

--- a/libraries/keybinds/keybinds-mcc0.0.23a_01-mcb1.7.3/src/main/resources/fabric.mod.json
+++ b/libraries/keybinds/keybinds-mcc0.0.23a_01-mcb1.7.3/src/main/resources/fabric.mod.json
@@ -6,6 +6,7 @@
   "mixins": [
     "osl.keybinds.mixins.json"
   ],
+  "accessWidener": "osl.keybinds.classtweaker",
   "depends": {
     "fabricloader": "\u003e\u003d0.18.0",
     "minecraft": "\u003e\u003d1.0.0-alpha.0.1.1 \u003c\u003d1.0.0-beta.7.3",

--- a/libraries/keybinds/keybinds-mcc0.0.23a_01-mcb1.7.3/src/main/resources/osl.keybinds.classtweaker
+++ b/libraries/keybinds/keybinds-mcc0.0.23a_01-mcb1.7.3/src/main/resources/osl.keybinds.classtweaker
@@ -1,0 +1,3 @@
+classTweaker	v1	named
+
+transitive-inject-interface	net/minecraft/client/options/KeyBinding	net/ornithemc/osl/keybinds/impl/keybind/KeyBindingExtensionImpl

--- a/libraries/keybinds/keybinds-mcc0.0.23a_01-mcb1.7.3/src/main/resources/osl.keybinds.mixins.json
+++ b/libraries/keybinds/keybinds-mcc0.0.23a_01-mcb1.7.3/src/main/resources/osl.keybinds.mixins.json
@@ -6,7 +6,8 @@
 	"mixins": [
 	],
 	"client": [
-		"client.GameOptionsMixin"
+		"client.GameOptionsMixin",
+		"client.KeyBindingMixin"
 	],
 	"server": [
 	],


### PR DESCRIPTION
This is a small update to the Keybinds API to make it more consistent with the new Blocks and Items API. 

## Changes

`KeybindRegistry` is a helper class with static access to the keybind registry, including registration methods. The `REGISTER_KEYBINDS` event no longer supplies a registry instance, and modders should register their custom keybinds statically.

```java
KeybindEvents.REGISTER_KEYBINDS.register(() -> {
	cookieKeybind = KeybindRegistry.register("cookie", GLFW.GLFW_KEY_Z, "example");
});
```

## Keybind Categories

V2 adds support for keybind categories to versions below 1.7. These are unused as the API does not modify the controls screen. 

## Notes on V1

The Keybinds V1 API is still present, but marked deprecated, and will be removed at a later date. The V1 API now internally makes use of the V2 API to function.