### PR TITLE
[blocks] change access of more protected methods in `Block`

### DIFF
--- a/libraries/blocks/blocks-mc13w36a-mc14w26c/src/main/resources/osl.blocks.classtweaker
+++ b/libraries/blocks/blocks-mc13w36a-mc14w26c/src/main/resources/osl.blocks.classtweaker
@@ -1,5 +1,8 @@
 classTweaker	v1	named
 
+transitive-accessible   method  net/minecraft/block/Block   <init>      (Lnet/minecraft/block/material/Material;)V
+transitive-accessible   method  net/minecraft/block/Block   setShape    (FFFFFF)V
+transitive-accessible   method  net/minecraft/block/Block   disableStats ()Lnet/minecraft/block/Block;
 transitive-accessible	method	net/minecraft/block/Block	setSounds	(Lnet/minecraft/block/Block$Sounds;)Lnet/minecraft/block/Block;
 transitive-accessible	method	net/minecraft/block/Block	setOpacity	(I)Lnet/minecraft/block/Block;
 transitive-accessible	method	net/minecraft/block/Block	setLight	(F)Lnet/minecraft/block/Block;


### PR DESCRIPTION
This small PR changes the access modifiers of the following methods in `Block` to public:

- `Block` (ctor/init)
- `Block.setShape`
- `Block.disableStats`

I was also thinking of doing it for other blocks that have their constructor private, such as `Sponge`, `LiquidBlock`s and items. But unsure if I should do it right now, I'd need some confirmation if that's needed/allowed.