### PR TITLE
Refactor NamespacedIdentifier#identifier -> NamespacedIdentifier#path

### DIFF
--- a/libraries/core/core-mc14w27a-mc1.14.4/src/main/java/net/ornithemc/osl/core/impl/mixin/common/IdentifierMixin.java
+++ b/libraries/core/core-mc14w27a-mc1.14.4/src/main/java/net/ornithemc/osl/core/impl/mixin/common/IdentifierMixin.java
@@ -13,20 +13,13 @@ import net.ornithemc.osl.core.api.util.NamespacedIdentifiers;
 
 @Mixin(Identifier.class)
 public class IdentifierMixin implements NamespacedIdentifier {
-
 	@Shadow
 	private String namespace;
+
 	@Shadow
 	private String path;
 
-	@Inject(
-		method = "equals",
-		remap = false,
-		cancellable = true,
-		at = @At(
-			value = "HEAD"
-		)
-	)
+	@Inject(method = "equals", at = @At(value = "HEAD"), cancellable = true, remap = false)
 	private void osl$core$equalsNamespacedIdentifier(Object o, CallbackInfoReturnable<Boolean> cir) {
 		if (o instanceof NamespacedIdentifier) {
 			cir.setReturnValue(NamespacedIdentifiers.equals(this, (NamespacedIdentifier) o));
@@ -39,7 +32,7 @@ public class IdentifierMixin implements NamespacedIdentifier {
 	}
 
 	@Override
-	public String identifier() {
+	public String path() {
 		return path;
 	}
 }

--- a/libraries/core/core-mca1.0.1_01-mc14w26c/src/main/java/net/ornithemc/osl/core/impl/mixin/client/IdentifierMixin.java
+++ b/libraries/core/core-mca1.0.1_01-mc14w26c/src/main/java/net/ornithemc/osl/core/impl/mixin/client/IdentifierMixin.java
@@ -13,20 +13,13 @@ import net.ornithemc.osl.core.api.util.NamespacedIdentifiers;
 
 @Mixin(Identifier.class)
 public class IdentifierMixin implements NamespacedIdentifier {
-
 	@Shadow
 	private String namespace;
+
 	@Shadow
 	private String path;
 
-	@Inject(
-		method = "equals",
-		remap = false,
-		cancellable = true,
-		at = @At(
-			value = "HEAD"
-		)
-	)
+	@Inject(method = "equals", at = @At(value = "HEAD"), cancellable = true, remap = false)
 	private void osl$core$equalsNamespacedIdentifier(Object o, CallbackInfoReturnable<Boolean> cir) {
 		if (o instanceof NamespacedIdentifier) {
 			cir.setReturnValue(NamespacedIdentifiers.equals(this, (NamespacedIdentifier) o));
@@ -39,7 +32,7 @@ public class IdentifierMixin implements NamespacedIdentifier {
 	}
 
 	@Override
-	public String identifier() {
+	public String path() {
 		return path;
 	}
 }

--- a/libraries/core/src/main/java/net/ornithemc/osl/core/api/util/NamespacedIdentifier.java
+++ b/libraries/core/src/main/java/net/ornithemc/osl/core/api/util/NamespacedIdentifier.java
@@ -23,7 +23,12 @@ public interface NamespacedIdentifier {
 	 * The separator between the namespace and identifier in the {@code String}
 	 * representation of a {@code NamespacedIdentifier}.
 	 */
-	static char SEPARATOR = ':';
+	char SEPARATOR = ':';
+
+	/**
+	 * The {@code minecraft} namespace, used for Vanilla resources and ids.
+	 */
+	String VANILLA_NAMESPACE = "minecraft";
 
 	/**
 	 * @return the namespace of this {@code NamespacedIdentifier}.
@@ -31,8 +36,13 @@ public interface NamespacedIdentifier {
 	String namespace();
 
 	/**
-	 * @return the identifier of this {@code NamespacedIdentifier}.
+	 * @return the path of this {@code NamespacedIdentifier}.
 	 */
-	String identifier();
+	String path();
+
+	@Deprecated
+	default String identifier() {
+		return this.path();
+	}
 
 }

--- a/libraries/core/src/main/java/net/ornithemc/osl/core/api/util/NamespacedIdentifiers.java
+++ b/libraries/core/src/main/java/net/ornithemc/osl/core/api/util/NamespacedIdentifiers.java
@@ -10,61 +10,41 @@ import net.ornithemc.osl.core.impl.util.NamespacedIdentifierImpl;
  * Utility methods for creating and validating {@link NamespacedIdentifier}s.
  */
 public final class NamespacedIdentifiers {
-
-	/**
-	 * The {@code minecraft} namespace is used for Vanilla resources and ids.
-	 */
-	public static final String MINECRAFT_NAMESPACE = "minecraft";
-	/**
-	 * The default namespace of {@code NamespacedIdentifier}s.
-	 * It is recommended to use a custom namespace for your own identifiers.
-	 */
-	public static final String DEFAULT_NAMESPACE = MINECRAFT_NAMESPACE;
-
 	/**
 	 * The maximum length of a {@code NamespacedIdentifier}'s namespace string.
 	 */
 	public static final int MAX_LENGTH_NAMESPACE = Integer.MAX_VALUE;
+
 	/**
-	 * The maximum length of a {@code NamespacedIdentifier} identifier string.
+	 * The maximum length of a {@code NamespacedIdentifier} path string.
 	 */
-	public static final int MAX_LENGTH_IDENTIFIER = Integer.MAX_VALUE;
+	public static final int MAX_LENGTH_PATH = Integer.MAX_VALUE;
 
 	/**
-	 * A comparator for {@code NamespacedIdentifier}s, comparing first by identifier, then by namespace.
+	 * A comparator for {@code NamespacedIdentifier}s, comparing first by path, then by namespace.
 	 */
-	public static final Comparator<NamespacedIdentifier> COMPARATOR = (a, b) -> {
-		int c = a.identifier().compareTo(b.identifier());
-		if (c == 0) {
-			c = a.namespace().compareTo(b.namespace());
-		}
-
-		return c;
-	};
+	public static final Comparator<NamespacedIdentifier> COMPARATOR = Comparator.comparing(NamespacedIdentifier::path).thenComparing(NamespacedIdentifier::namespace);
 
 	/**
-	 * Construct and validate a {@code NamespacedIdentifier} with the default namespace and the given identifier.
+	 * Construct and validate a {@code NamespacedIdentifier} with the default namespace and the given path.
 	 * 
-	 * @return a {@code NamespacedIdentifier} with the default namespace and the given identifier.
+	 * @return a {@code NamespacedIdentifier} with the default namespace and the given path.
 	 * @throws NamespacedIdentifierException
 	 *   if the given identifier is invalid.
 	 */
-	public static NamespacedIdentifier from(String identifier) {
-		return from(DEFAULT_NAMESPACE, identifier);
+	public static NamespacedIdentifier from(String path) {
+		return from(NamespacedIdentifier.VANILLA_NAMESPACE, path);
 	}
 
 	/**
-	 * Construct and validate a {@code NamespacedIdentifier} from the given namespace and identifier.
+	 * Construct and validate a {@code NamespacedIdentifier} from the given namespace and path.
 	 * 
-	 * @return a {@code NamespacedIdentifier} with the given namespace and identifier.
+	 * @return a {@code NamespacedIdentifier} with the given namespace and path.
 	 * @throws NamespacedIdentifierException
 	 *   if the given namespace or identifier is invalid.
 	 */
-	public static NamespacedIdentifier from(String namespace, String identifier) {
-		return new NamespacedIdentifierImpl(
-			validateNamespace(namespace),
-			validateIdentifier(identifier)
-		);
+	public static NamespacedIdentifier from(String namespace, String path) {
+		return new NamespacedIdentifierImpl(validateNamespace(namespace), validatePath(path));
 	}
 
 	/**
@@ -76,19 +56,18 @@ public final class NamespacedIdentifiers {
 	 * @throws NamespacedIdentifierParseException
 	 *   if no valid {@code NamespacedIdentifier} can be parsed from the given {@code String}.
 	 */
-	public static NamespacedIdentifier parse(String s) {
-		int i = s.indexOf(NamespacedIdentifier.SEPARATOR);
-
+	public static NamespacedIdentifier parse(String input) {
+		int index = input.indexOf(NamespacedIdentifier.SEPARATOR);
 		try {
-			if (i < 0) {
-				return from(s.substring(i + 1));
-			} else if (i > 0) {
-				return from(s.substring(0, i), s.substring(i + 1));
+			if (index < 0) {
+				return from(input.substring(index + 1));
+			} else if (index > 0) {
+				return from(input.substring(0, index), input.substring(index + 1));
 			} else {
-				throw NamespacedIdentifierParseException.invalid(s, "badly formatted");
+				throw NamespacedIdentifierParseException.invalid(input, "badly formatted");
 			}
-		} catch (NamespacedIdentifierException e) {
-			throw NamespacedIdentifierParseException.invalid(s, e);
+		} catch (NamespacedIdentifierException exception) {
+			throw NamespacedIdentifierParseException.invalid(input, exception);
 		}
 	}
 
@@ -98,11 +77,10 @@ public final class NamespacedIdentifiers {
 	public static NamespacedIdentifier validate(NamespacedIdentifier id) {
 		try {
 			validateNamespace(id.namespace());
-			validateIdentifier(id.identifier());
-
+			validatePath(id.path());
 			return id;
-		} catch (NamespacedIdentifierException e) {
-			throw NamespacedIdentifierException.invalid(id, e);
+		} catch (NamespacedIdentifierException exception) {
+			throw NamespacedIdentifierException.invalid(id, exception);
 		}
 	}
 
@@ -113,9 +91,11 @@ public final class NamespacedIdentifiers {
 		if (namespace == null || namespace.isEmpty()) {
 			throw NamespacedIdentifierException.invalidNamespace(namespace, "null or empty");
 		}
+
 		if (namespace.length() > MAX_LENGTH_NAMESPACE) {
 			throw NamespacedIdentifierException.invalidNamespace(namespace, "length " + namespace.length() + " is greater than maximum allowed " + MAX_LENGTH_NAMESPACE);
 		}
+
 		if (!namespace.chars().allMatch(chr -> chr == '-' || chr == '.' || chr == '_' || (chr >= 'a' && chr <= 'z') || (chr >= 'A' && chr <= 'Z') || (chr >= '0' && chr <= '9'))) {
 			throw NamespacedIdentifierException.invalidNamespace(namespace, "contains illegal characters - only [a-zA-Z0-9-._] are allowed");
 		}
@@ -124,23 +104,25 @@ public final class NamespacedIdentifiers {
 	}
 
 	/**
-	 * Check that the given identifier is valid for a {@code NamespacedIdentifier}.
+	 * Check that the given path is valid for a {@code NamespacedIdentifier}.
 	 */
-	public static String validateIdentifier(String identifier) {
-		if (identifier == null || identifier.isEmpty()) {
-			throw NamespacedIdentifierException.invalidIdentifier(identifier, "null or empty");
-		}
-		if (identifier.length() > MAX_LENGTH_IDENTIFIER) {
-			throw NamespacedIdentifierException.invalidIdentifier(identifier, "length " + identifier.length() + " is greater than maximum allowed " + MAX_LENGTH_IDENTIFIER);
-		}
-		if (!identifier.chars().allMatch(chr -> chr == '-' || chr == '.' || chr == '_' || chr == '/' || (chr >= 'a' && chr <= 'z') || (chr >= 'A' && chr <= 'Z') || (chr >= '0' && chr <= '9'))) {
-			throw NamespacedIdentifierException.invalidIdentifier(identifier, "contains illegal characters - only [a-zA-Z0-9-._/] are allowed");
+	public static String validatePath(String path) {
+		if (path == null || path.isEmpty()) {
+			throw NamespacedIdentifierException.invalidPath(path, "null or empty");
 		}
 
-		return identifier;
+		if (path.length() > MAX_LENGTH_PATH) {
+			throw NamespacedIdentifierException.invalidPath(path, "length " + path.length() + " is greater than maximum allowed " + MAX_LENGTH_PATH);
+		}
+
+		if (!path.chars().allMatch(chr -> chr == '-' || chr == '.' || chr == '_' || chr == '/' || (chr >= 'a' && chr <= 'z') || (chr >= 'A' && chr <= 'Z') || (chr >= '0' && chr <= '9'))) {
+			throw NamespacedIdentifierException.invalidPath(path, "contains illegal characters - only [a-zA-Z0-9-._/] are allowed");
+		}
+
+		return path;
 	}
 
-	public static boolean equals(NamespacedIdentifier a, NamespacedIdentifier b) {
-		return a.namespace().equals(b.namespace()) && a.identifier().equals(b.identifier());
+	public static boolean equals(NamespacedIdentifier left, NamespacedIdentifier right) {
+		return left.namespace().equals(right.namespace()) && left.path().equals(right.path());
 	}
 }

--- a/libraries/core/src/main/java/net/ornithemc/osl/core/impl/util/IdentifierImpl.java
+++ b/libraries/core/src/main/java/net/ornithemc/osl/core/impl/util/IdentifierImpl.java
@@ -5,14 +5,13 @@ import net.ornithemc.osl.core.api.util.NamespacedIdentifier;
 // This interface is used for transitive interface injection into Identifier.
 // Its purpose is to provide method implementations to keep the compiler happy.
 public interface IdentifierImpl extends NamespacedIdentifier {
-
 	@Override
 	default String namespace() {
 		throw new AbstractMethodError("Not implemented!");
 	}
 
 	@Override
-	default String identifier() {
+	default String path() {
 		throw new AbstractMethodError("Not implemented!");
 	}
 }

--- a/libraries/core/src/main/java/net/ornithemc/osl/core/impl/util/NamespacedIdentifierException.java
+++ b/libraries/core/src/main/java/net/ornithemc/osl/core/impl/util/NamespacedIdentifierException.java
@@ -4,7 +4,6 @@ import net.ornithemc.osl.core.api.util.NamespacedIdentifier;
 
 @SuppressWarnings("serial")
 public class NamespacedIdentifierException extends RuntimeException {
-
 	private NamespacedIdentifierException(String message) {
 		super(message);
 	}
@@ -25,7 +24,7 @@ public class NamespacedIdentifierException extends RuntimeException {
 		return new NamespacedIdentifierException("\'" + namespace + "\' is not a valid namespace: " + reason);
 	}
 
-	public static NamespacedIdentifierException invalidIdentifier(String identifier, String reason) {
-		return new NamespacedIdentifierException("\'" + identifier + "\' is not a valid identifier: " + reason);
+	public static NamespacedIdentifierException invalidPath(String path, String reason) {
+		return new NamespacedIdentifierException("\'" + path + "\' is not a valid path: " + reason);
 	}
 }

--- a/libraries/core/src/main/java/net/ornithemc/osl/core/impl/util/NamespacedIdentifierImpl.java
+++ b/libraries/core/src/main/java/net/ornithemc/osl/core/impl/util/NamespacedIdentifierImpl.java
@@ -16,11 +16,11 @@ import net.ornithemc.osl.core.api.util.NamespacedIdentifiers;
 public final class NamespacedIdentifierImpl implements NamespacedIdentifier {
 
 	private final String namespace;
-	private final String identifier;
+	private final String path;
 
-	public NamespacedIdentifierImpl(String namespace, String identifier) {
+	public NamespacedIdentifierImpl(String namespace, String path) {
 		this.namespace = namespace;
-		this.identifier = identifier;
+		this.path = path;
 	}
 
 	@Override
@@ -37,12 +37,12 @@ public final class NamespacedIdentifierImpl implements NamespacedIdentifier {
 	@Override
 	public int hashCode() {
 		// this impl matches Vanilla Identifier's impl
-		return 31 * namespace.hashCode() + identifier.hashCode();
+		return 31 * namespace.hashCode() + path.hashCode();
 	}
 
 	@Override
 	public String toString() {
-		return namespace + SEPARATOR + identifier;
+		return namespace + SEPARATOR + path;
 	}
 
 	@Override
@@ -51,7 +51,7 @@ public final class NamespacedIdentifierImpl implements NamespacedIdentifier {
 	}
 
 	@Override
-	public String identifier() {
-		return identifier;
+	public String path() {
+		return path;
 	}
 }

--- a/libraries/networking/src/main/java/net/ornithemc/osl/networking/api/ChannelIdentifiers.java
+++ b/libraries/networking/src/main/java/net/ornithemc/osl/networking/api/ChannelIdentifiers.java
@@ -12,12 +12,11 @@ import net.ornithemc.osl.networking.impl.ChannelIdentifierException;
  * Utility methods for creating and validating channel identifiers.
  */
 public final class ChannelIdentifiers {
-
 	/**
 	 * The default namespace of channel identifiers.
 	 * It is recommended to use a custom namespace for your own identifiers.
 	 */
-	public static final String DEFAULT_NAMESPACE = NamespacedIdentifiers.DEFAULT_NAMESPACE;
+	public static final String DEFAULT_NAMESPACE = NamespacedIdentifier.VANILLA_NAMESPACE;
 
 	/**
 	 * The maximum length of a channel identifier's namespace string.
@@ -26,23 +25,20 @@ public final class ChannelIdentifiers {
 	/**
 	 * The maximum length of a channel identifier's identifier string.
 	 */
-	public static final int MAX_LENGTH_IDENTIFIER = Byte.MAX_VALUE;
+	public static final int MAX_LENGTH_PATH = Byte.MAX_VALUE;
 
 	/**
-	 * Construct and validate a channel identifier with the default namespace and the given identifier.
+	 * Construct and validate a channel identifier with the default namespace and the given path.
 	 */
-	public static NamespacedIdentifier from(String identifier) {
-		return from(DEFAULT_NAMESPACE, identifier);
+	public static NamespacedIdentifier from(String path) {
+		return from(DEFAULT_NAMESPACE, path);
 	}
 
 	/**
-	 * Construct and validate a channel identifier from the given namespace and identifier.
+	 * Construct and validate a channel identifier from the given namespace and path.
 	 */
-	public static NamespacedIdentifier from(String namespace, String identifier) {
-		return NamespacedIdentifiers.from(
-			validateNamespace(namespace),
-			validateIdentifier(identifier)
-		);
+	public static NamespacedIdentifier from(String namespace, String path) {
+		return NamespacedIdentifiers.from(validateNamespace(namespace), validatePath(path));
 	}
 
 	/**
@@ -51,11 +47,10 @@ public final class ChannelIdentifiers {
 	public static NamespacedIdentifier validate(NamespacedIdentifier id) {
 		try {
 			validateNamespace(id.namespace());
-			validateIdentifier(id.identifier());
-
+			validatePath(id.path());
 			return id;
-		} catch (ChannelIdentifierException e) {
-			throw ChannelIdentifierException.invalid(id, e);
+		} catch (ChannelIdentifierException exception) {
+			throw ChannelIdentifierException.invalid(id, exception);
 		}
 	}
 
@@ -66,9 +61,11 @@ public final class ChannelIdentifiers {
 		if (namespace == null || namespace.isEmpty()) {
 			throw ChannelIdentifierException.invalidNamespace(namespace, "null or empty");
 		}
+
 		if (namespace.length() > MAX_LENGTH_NAMESPACE) {
 			throw ChannelIdentifierException.invalidNamespace(namespace, "length " + namespace.length() + " is greater than maximum allowed " + MAX_LENGTH_NAMESPACE);
 		}
+
 		if (!namespace.chars().allMatch(chr -> chr == '-' || chr == '.' || chr == '_' || (chr >= 'a' && chr <= 'z') || (chr >= '0' && chr <= '9'))) {
 			throw ChannelIdentifierException.invalidNamespace(namespace, "contains illegal characters - only [a-z0-9-._] are allowed");
 		}
@@ -77,20 +74,22 @@ public final class ChannelIdentifiers {
 	}
 
 	/**
-	 * Check that the given identifier is valid for a channel identifier.
+	 * Check that the given path is valid for a channel identifier.
 	 */
-	public static String validateIdentifier(String identifier) {
-		if (identifier == null || identifier.isEmpty()) {
-			throw ChannelIdentifierException.invalidIdentifier(identifier, "null or empty");
-		}
-		if (identifier.length() > MAX_LENGTH_IDENTIFIER) {
-			throw ChannelIdentifierException.invalidIdentifier(identifier, "length " + identifier.length() + " is greater than maximum allowed " + MAX_LENGTH_IDENTIFIER);
-		}
-		if (!identifier.chars().allMatch(chr -> chr == '-' || chr == '.' || chr == '_' || chr == '/' || (chr >= 'a' && chr <= 'z') || (chr >= '0' && chr <= '9'))) {
-			throw ChannelIdentifierException.invalidIdentifier(identifier, "contains illegal characters - only [a-z0-9-._/] are allowed");
+	public static String validatePath(String path) {
+		if (path == null || path.isEmpty()) {
+			throw ChannelIdentifierException.invalidPath(path, "null or empty");
 		}
 
-		return NamespacedIdentifiers.validateIdentifier(identifier);
+		if (path.length() > MAX_LENGTH_PATH) {
+			throw ChannelIdentifierException.invalidPath(path, "length " + path.length() + " is greater than maximum allowed " + MAX_LENGTH_PATH);
+		}
+
+		if (!path.chars().allMatch(chr -> chr == '-' || chr == '.' || chr == '_' || chr == '/' || (chr >= 'a' && chr <= 'z') || (chr >= '0' && chr <= '9'))) {
+			throw ChannelIdentifierException.invalidPath(path, "contains illegal characters - only [a-z0-9-._/] are allowed");
+		}
+
+		return NamespacedIdentifiers.validatePath(path);
 	}
 
 	public static Set<NamespacedIdentifier> dropInvalid(Set<NamespacedIdentifier> channels) {

--- a/libraries/networking/src/main/java/net/ornithemc/osl/networking/api/StringChannelIdentifierParser.java
+++ b/libraries/networking/src/main/java/net/ornithemc/osl/networking/api/StringChannelIdentifierParser.java
@@ -13,7 +13,7 @@ public final class StringChannelIdentifierParser {
 	/**
 	 * The maximum allowed length for the {@code String} representation of a channel identifier.
 	 */
-	public static final int MAX_LENGTH = ChannelIdentifiers.MAX_LENGTH_NAMESPACE + 1 + ChannelIdentifiers.MAX_LENGTH_IDENTIFIER;
+	public static final int MAX_LENGTH = ChannelIdentifiers.MAX_LENGTH_NAMESPACE + 1 + ChannelIdentifiers.MAX_LENGTH_PATH;
 
 	/**
 	 * Convert the given {@code String} to a channel identifier.

--- a/libraries/networking/src/main/java/net/ornithemc/osl/networking/impl/ChannelIdentifierException.java
+++ b/libraries/networking/src/main/java/net/ornithemc/osl/networking/impl/ChannelIdentifierException.java
@@ -4,7 +4,6 @@ import net.ornithemc.osl.core.api.util.NamespacedIdentifier;
 
 @SuppressWarnings("serial")
 public class ChannelIdentifierException extends RuntimeException {
-
 	private ChannelIdentifierException(String message) {
 		super(message);
 	}
@@ -25,7 +24,7 @@ public class ChannelIdentifierException extends RuntimeException {
 		return new ChannelIdentifierException("\'" + namespace + "\' is not a valid namespace: " + reason);
 	}
 
-	public static ChannelIdentifierException invalidIdentifier(String identifier, String reason) {
-		return new ChannelIdentifierException("\'" + identifier + "\' is not a valid identifier: " + reason);
+	public static ChannelIdentifierException invalidPath(String path, String reason) {
+		return new ChannelIdentifierException("\'" + path + "\' is not a valid path: " + reason);
 	}
 }


### PR DESCRIPTION
The reasoning behind this is that a Identifier does not hold a child "identifier", and every other impl from Modern to other things name it the "path" of the Identifier. calling ``identifier.identifier`` makes 0 sense.

I also moved the vanilla namespace constant to NamespacedIdentifier as I think it belongs there instead for more convinent access as thats where people would think to look for it at, as before I did not know it existed elsewhere.

I have left a ``@Deprecated`` implementation of ``identifier`` that redirects to path, so that peoples projects will continue to work for the time being.

I also fixed some variable names and tried to tidy it up a bit to be more readable, alongside making the comparator use Comparator chaining.