### PR TITLE
Block Entities API

### DIFF
--- a/libraries/blockentities-rendering/README.md
+++ b/libraries/blockentities-rendering/README.md
@@ -1,0 +1,26 @@
+# Block Entities Rendering API
+
+The Block Entities Rendering API provides events and utilities for registering and working with block entity renderers.
+
+## Registering Custom Block Entity Renderers
+
+Block entity renderer registration should be done in a listener to the `REGISTER_BLOCK_ENTITY_RENDERERS` event.
+
+An example is shown below.
+
+```java
+package com.example;
+
+import net.ornithemc.osl.blockentities.api.client.BlockEntityRenderingEvents;
+import net.ornithemc.osl.entrypoints.api.client.ClientModInitializer;
+
+public class ExampleInitializer implements ClientModInitializer {
+
+	@Override
+	public void initClient() {
+		BlockEntityRenderingEvents.REGISTER_BLOCK_ENTITY_RENDERERS.register(registry -> {
+			registry.register(CookieBlockEntity.class, CookieBlockRenderer::new);
+		});
+	}
+}
+```

--- a/libraries/blockentities-rendering/blockentities-rendering-mca1.0.1_01-mc1.14.4/build.gradle
+++ b/libraries/blockentities-rendering/blockentities-rendering-mca1.0.1_01-mc1.14.4/build.gradle
@@ -1,0 +1,1 @@
+setUpModule(project)

--- a/libraries/blockentities-rendering/blockentities-rendering-mca1.0.1_01-mc1.14.4/gradle.properties
+++ b/libraries/blockentities-rendering/blockentities-rendering-mca1.0.1_01-mc1.14.4/gradle.properties
@@ -1,0 +1,8 @@
+environment = client
+min_mc_version = a1.0.1_01
+max_mc_version = 1.14.4
+
+minecraft_version = 1.7.2
+raven_build = 1
+sparrow_build = 1
+nests_build = 3

--- a/libraries/blockentities-rendering/blockentities-rendering-mca1.0.1_01-mc1.14.4/src/main/java/net/ornithemc/osl/blockentities/api/client/BlockEntityRendererRegistry.java
+++ b/libraries/blockentities-rendering/blockentities-rendering-mca1.0.1_01-mc1.14.4/src/main/java/net/ornithemc/osl/blockentities/api/client/BlockEntityRendererRegistry.java
@@ -1,0 +1,24 @@
+package net.ornithemc.osl.blockentities.api.client;
+
+import java.util.function.Supplier;
+
+import net.minecraft.block.entity.BlockEntity;
+import net.minecraft.client.render.block.entity.BlockEntityRenderDispatcher;
+import net.minecraft.client.render.block.entity.BlockEntityRenderer;
+
+/**
+ * A wrapper around the {@linkplain BlockEntityRenderDispatcher} renderers map.
+ */
+@FunctionalInterface
+public interface BlockEntityRendererRegistry {
+
+	/**
+	 * Registers the given block entity renderer for the given block entity type.
+	 * 
+	 * @param <T>     the block entity type for which to register the renderer.
+	 * @param type    the block entity type class.
+	 * @param factory the factory for the block entity renderer to register.
+	 */
+	<T extends BlockEntity> void register(Class<T> type, Supplier<BlockEntityRenderer<? super T>> factory);
+
+}

--- a/libraries/blockentities-rendering/blockentities-rendering-mca1.0.1_01-mc1.14.4/src/main/java/net/ornithemc/osl/blockentities/api/client/BlockEntityRenderingEvents.java
+++ b/libraries/blockentities-rendering/blockentities-rendering-mca1.0.1_01-mc1.14.4/src/main/java/net/ornithemc/osl/blockentities/api/client/BlockEntityRenderingEvents.java
@@ -1,0 +1,34 @@
+package net.ornithemc.osl.blockentities.api.client;
+
+import java.util.function.Consumer;
+
+import net.ornithemc.osl.core.api.events.Event;
+
+/**
+ * Events related to the block entities rendering lifecycle.
+ */
+public final class BlockEntityRenderingEvents {
+
+	/**
+	 * This event is invoked upon client start-up, after Vanilla block entity renderer registration is finished.
+	 * 
+	 * <p>
+	 * Custom block entity renderer registration should be done in a listener of this event.
+	 * 
+	 * <p>
+	 * Listeners to this event should be registered in your mod's entrypoint,
+	 * and can be done as follows:
+	 * 
+	 * <pre>
+	 * {@code
+	 * BlockEntityRenderingEvents.REGISTER_BLOCK_ENTITY_RENDERERS.register(registry -> {
+	 * 	registry.register(CookieBlockEntity.class, CookieBlockRenderer::new);
+	 * });
+	 * }
+	 * </pre>
+	 * 
+	 * @see BlockEntityRendererRegistry
+	 */
+	public static final Event<Consumer<BlockEntityRendererRegistry>> REGISTER_BLOCK_ENTITY_RENDERERS = Event.consumer();
+
+}

--- a/libraries/blockentities-rendering/blockentities-rendering-mca1.0.1_01-mc1.14.4/src/main/java/net/ornithemc/osl/blockentities/impl/mixin/client/BlockEntityRenderDispatcherMixin.java
+++ b/libraries/blockentities-rendering/blockentities-rendering-mca1.0.1_01-mc1.14.4/src/main/java/net/ornithemc/osl/blockentities/impl/mixin/client/BlockEntityRenderDispatcherMixin.java
@@ -1,0 +1,41 @@
+package net.ornithemc.osl.blockentities.impl.mixin.client;
+
+import java.util.Map;
+import java.util.function.Supplier;
+
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import net.minecraft.block.entity.BlockEntity;
+import net.minecraft.client.render.block.entity.BlockEntityRenderDispatcher;
+import net.minecraft.client.render.block.entity.BlockEntityRenderer;
+
+import net.ornithemc.osl.blockentities.api.client.BlockEntityRenderingEvents;
+
+@Mixin(BlockEntityRenderDispatcher.class)
+public class BlockEntityRenderDispatcherMixin {
+
+	@Shadow @Final
+	private Map<Class<? extends BlockEntity>, BlockEntityRenderer<? extends BlockEntity>> renderers;
+
+	@Inject(
+		method = "<init>",
+		at = @At(
+			value = "INVOKE",
+			target = "Ljava/util/Map;values()Ljava/util/Collection;"
+		)
+	)
+	private void osl$blockentities$registerBlockEntityRenderers(CallbackInfo ci) {
+		BlockEntityRenderingEvents.REGISTER_BLOCK_ENTITY_RENDERERS.invoker().accept(this::register);
+	}
+
+	@Unique
+	private <T extends BlockEntity> void register(Class<T> type, Supplier<BlockEntityRenderer<? super T>> factory) {
+		this.renderers.put(type, factory.get());
+	}
+}

--- a/libraries/blockentities-rendering/blockentities-rendering-mca1.0.1_01-mc1.14.4/src/main/resources/fabric.mod.json
+++ b/libraries/blockentities-rendering/blockentities-rendering-mca1.0.1_01-mc1.14.4/src/main/resources/fabric.mod.json
@@ -1,0 +1,26 @@
+{
+  "schemaVersion": 1,
+  "id": "osl-blockentities-rendering",
+  "version": "0.1.0+mca1.0.1_01-mc1.14.4",
+  "environment": "client",
+  "mixins": [
+    "osl.blockentities-rendering.mixins.json"
+  ],
+  "depends": {
+    "fabricloader": "\u003e\u003d0.18.0",
+    "minecraft": "\u003e\u003d1.0.0-alpha.0.1.1 \u003c\u003d1.14.4",
+    "osl-core": "\u003e\u003d0.9.0",
+    "osl-entrypoints": "\u003e\u003d0.5.0"
+  },
+  "name": "OSL Block Entities Rendering",
+  "description": "Block Entities Rendering API and events.",
+  "authors": [
+    "OrnitheMC"
+  ],
+  "contact": {
+    "homepage": "https://ornithemc.net/",
+    "issues": "https://github.com/OrnitheMC/ornithe-standard-libraries/issues",
+    "sources": "https://github.com/OrnitheMC/ornithe-standard-libraries"
+  },
+  "license": "Apache-2.0"
+}

--- a/libraries/blockentities-rendering/blockentities-rendering-mca1.0.1_01-mc1.14.4/src/main/resources/osl.blockentities-rendering.mixins.json
+++ b/libraries/blockentities-rendering/blockentities-rendering-mca1.0.1_01-mc1.14.4/src/main/resources/osl.blockentities-rendering.mixins.json
@@ -1,0 +1,16 @@
+{
+	"required": true,
+	"minVersion": "0.8",
+	"package": "net.ornithemc.osl.blockentities.impl.mixin",
+	"compatibilityLevel": "JAVA_8",
+	"mixins": [
+	],
+	"client": [
+		"client.BlockEntityRenderDispatcherMixin"
+	],
+	"server": [
+	],
+	"injectors": {
+		"defaultRequire": 1
+	}
+}

--- a/libraries/blockentities-rendering/build.gradle
+++ b/libraries/blockentities-rendering/build.gradle
@@ -1,0 +1,1 @@
+setUpLibrary(project)

--- a/libraries/blockentities-rendering/gradle.properties
+++ b/libraries/blockentities-rendering/gradle.properties
@@ -1,0 +1,6 @@
+library_id = blockentities-rendering
+library_name = Block Entities Rendering
+library_description = Block Entities Rendering API and events.
+library_version = 0.1.0
+
+osl_dependencies = core:0.9.0,entrypoints:0.5.0

--- a/libraries/blockentities/README.md
+++ b/libraries/blockentities/README.md
@@ -1,0 +1,42 @@
+# Block Entities API
+
+The Block Entities API provides events and utilities for registering and working with block entities.
+
+## Registering Custom Block Entity Types
+
+Block entity type registration should be done in a listener to the `REGISTER_BLOCK_ENTITY_TYPES` event. The `BlockEntityTypeRegistry` class provides utility methods for registering block entity types.
+
+An example is shown below.
+
+```java
+package com.example;
+
+import net.ornithemc.osl.blockentities.api.BlockEntityEvents;
+import net.ornithemc.osl.entrypoints.api.ModInitializer;
+
+public class ExampleInitializer implements ModInitializer {
+
+	@Override
+	public void init() {
+		BlockEntityEvents.REGISTER_BLOCK_ENTITY_TYPES.register(ExampleBlockEntityTypes::init);
+	}
+}
+```
+
+```java
+package com.example;
+
+import net.minecraft.block.entity.BlockEntityType;
+
+import net.ornithemc.osl.blockentities.api.BlockEntityTypeRegistry;
+import net.ornithemc.osl.blockentities.api.BlockEntityTypes;
+import net.ornithemc.osl.core.util.NamespacedIdentifiers;
+
+public final class ExampleBlockEntityTypes {
+
+	public static final BlockEntityType<CookieBlockEntity> COOKIE = BlockEntityTypeRegistry.register(NamespacedIdentifiers.from("example", "cookie"), BlockEntityTypes.builder(CookieBlockEntity::new, ExampleBlocks.COOKIE));
+
+	public static void init() {
+	}
+}
+```

--- a/libraries/blockentities/blockentities-mc1.13-pre5-mc18w31a/build.gradle
+++ b/libraries/blockentities/blockentities-mc1.13-pre5-mc18w31a/build.gradle
@@ -1,0 +1,1 @@
+setUpModule(project)

--- a/libraries/blockentities/blockentities-mc1.13-pre5-mc18w31a/gradle.properties
+++ b/libraries/blockentities/blockentities-mc1.13-pre5-mc18w31a/gradle.properties
@@ -1,0 +1,4 @@
+min_mc_version = 1.13-pre5
+max_mc_version = 18w31a
+
+minecraft_version = 1.13

--- a/libraries/blockentities/blockentities-mc1.13-pre5-mc18w31a/src/main/java/net/ornithemc/osl/blockentities/api/BlockEntityEvents.java
+++ b/libraries/blockentities/blockentities-mc1.13-pre5-mc18w31a/src/main/java/net/ornithemc/osl/blockentities/api/BlockEntityEvents.java
@@ -1,0 +1,35 @@
+package net.ornithemc.osl.blockentities.api;
+
+import net.ornithemc.osl.core.api.events.Event;
+
+/**
+ * Events related to the block entities lifecycle.
+ */
+public final class BlockEntityEvents {
+
+	/**
+	 * This event is invoked upon game start-up, after Vanilla block entity registration is finished.
+	 * 
+	 * <p>
+	 * Custom block entity type registration should be done in a listener of this event.
+	 * Helper methods for registering block entity types can be found in the {@linkplain
+	 * BlockEntityTypeRegistry} class.
+	 * 
+	 * <p>
+	 * Listeners to this event should be registered in your mod's entrypoint,
+	 * and can be done as follows:
+	 * 
+	 * <pre>
+	 * {@code
+	 * BlockEntityEvents.REGISTER_BLOCK_ENTITY_TYPES.register(() -> {
+	 * 	BlockEntityTypeRegistry.register(NamespacedIdentifiers.from("example", "cookie"), BlockEntityTypes.builder(CookieBlockEntity::new));
+	 * });
+	 * }
+	 * </pre>
+	 * 
+	 * @see BlockEntityTypeRegistry
+	 * @see BlockEntityTypes
+	 */
+	public static final Event<Runnable> REGISTER_BLOCK_ENTITY_TYPES = Event.runnable();
+
+}

--- a/libraries/blockentities/blockentities-mc1.13-pre5-mc18w31a/src/main/java/net/ornithemc/osl/blockentities/api/BlockEntityTypeRegistry.java
+++ b/libraries/blockentities/blockentities-mc1.13-pre5-mc18w31a/src/main/java/net/ornithemc/osl/blockentities/api/BlockEntityTypeRegistry.java
@@ -1,0 +1,95 @@
+package net.ornithemc.osl.blockentities.api;
+
+import java.util.Set;
+
+import net.minecraft.block.entity.BlockEntity;
+import net.minecraft.block.entity.BlockEntityType;
+
+import net.ornithemc.osl.blockentities.impl.BlockEntityTypeRegistryImpl;
+import net.ornithemc.osl.core.api.util.NamespacedIdentifier;
+import net.ornithemc.osl.registries.api.registry.Registry;
+import net.ornithemc.osl.registries.api.registry.ResourceKey;
+
+/**
+ * Public access to the Block Entity Types registry.
+ */
+public final class BlockEntityTypeRegistry {
+
+	public static final Registry<BlockEntityType<?>> REGISTRY = BlockEntityTypeRegistryImpl.REGISTRY;
+
+	/**
+	 * @return the numerical ID assigned to the given block entity type.
+	 */
+	public static int getId(BlockEntityType<?> type) {
+		return BlockEntityTypeRegistryImpl.getId(type);
+	}
+
+	/**
+	 * @return the namespaced ID assigned to the given block entity type.
+	 */
+	public static NamespacedIdentifier getIdentifier(BlockEntityType<?> type) {
+		return BlockEntityTypeRegistryImpl.getIdentifier(type);
+	}
+
+	/**
+	 * @return the resource key assigned to the given block entity type.
+	 */
+	public static ResourceKey<BlockEntityType<?>> getKey(BlockEntityType<?> type) {
+		return BlockEntityTypeRegistryImpl.getKey(type);
+	}
+
+	/**
+	 * @return the block entity type mapped to the given numerical ID.
+	 */
+	public static BlockEntityType<?> getBlockEntityType(int id) {
+		return BlockEntityTypeRegistryImpl.getBlockEntityType(id);
+	}
+
+	/**
+	 * @return the block entity type mapped to the given namespaced ID.
+	 */
+	public static BlockEntityType<?> getBlockEntityType(NamespacedIdentifier identifier) {
+		return BlockEntityTypeRegistryImpl.getBlockEntityType(identifier);
+	}
+
+	/**
+	 * @return the block entity type mapped to the given resource key.
+	 */
+	public static BlockEntityType<?> getBlockEntityType(ResourceKey<BlockEntityType<?>> key) {
+		return BlockEntityTypeRegistryImpl.getBlockEntityType(key);
+	}
+
+	/**
+	 * @return a set containing all namespaced IDs in the registry.
+	 */
+	public static Set<NamespacedIdentifier> identifierSet() {
+		return BlockEntityTypeRegistryImpl.identifierSet();
+	}
+
+	/**
+	 * @return a set containing all resource keys in the registry.
+	 */
+	public static Set<ResourceKey<BlockEntityType<?>>> keySet() {
+		return BlockEntityTypeRegistryImpl.keySet();
+	}
+
+	/**
+	 * @param <T>        the block entity type.
+	 * @param identifier the namespaced ID of the block entity type.
+	 * @param type       the builder for the block entity type to register.
+	 * @return the registered block entity type.
+	 */
+	public static <T extends BlockEntity> BlockEntityType<T> register(NamespacedIdentifier identifier, BlockEntityType.Builder<T> type) {
+		return BlockEntityTypeRegistryImpl.register(identifier, type);
+	}
+
+	/**
+	 * @param <T>   the block entity type.
+	 * @param key   the resource key of the block entity type.
+	 * @param type  the builder for the block entity type to register.
+	 * @return the registered block entity type.
+	 */
+	public static <T extends BlockEntity> BlockEntityType<T> register(ResourceKey<BlockEntityType<?>> key, BlockEntityType.Builder<T> type) {
+		return BlockEntityTypeRegistryImpl.register(key, type);
+	}
+}

--- a/libraries/blockentities/blockentities-mc1.13-pre5-mc18w31a/src/main/java/net/ornithemc/osl/blockentities/api/BlockEntityTypes.java
+++ b/libraries/blockentities/blockentities-mc1.13-pre5-mc18w31a/src/main/java/net/ornithemc/osl/blockentities/api/BlockEntityTypes.java
@@ -1,0 +1,19 @@
+package net.ornithemc.osl.blockentities.api;
+
+import java.util.function.Supplier;
+
+import net.minecraft.block.entity.BlockEntity;
+import net.minecraft.block.entity.BlockEntityType;
+
+/**
+ * Utilities for constructing and modifying block entity types.
+ */
+public final class BlockEntityTypes {
+
+	/**
+	 * @return a new block entity type builder with the given block entity factory.
+	 */
+	public static <T extends BlockEntity> BlockEntityType.Builder<T> builder(Supplier<? extends T> factory) {
+		return BlockEntityType.Builder.of(factory);
+	}
+}

--- a/libraries/blockentities/blockentities-mc1.13-pre5-mc18w31a/src/main/java/net/ornithemc/osl/blockentities/impl/BlockEntityTypeIdRegistry.java
+++ b/libraries/blockentities/blockentities-mc1.13-pre5-mc18w31a/src/main/java/net/ornithemc/osl/blockentities/impl/BlockEntityTypeIdRegistry.java
@@ -1,0 +1,20 @@
+package net.ornithemc.osl.blockentities.impl;
+
+import net.minecraft.block.entity.BlockEntityType;
+import net.minecraft.resource.Identifier;
+import net.minecraft.util.registry.IdRegistry;
+
+/**
+ * The block entity type registry is created and populated in BlockEntity's class initializer.
+ * This breaks OSL's usual pattern of registering the registry in the API entrypoint but
+ * triggering registry population during bootstrapping, since OSL has to wrap the Vanilla
+ * registry which is not possible without triggering BlockEntityType class load and registry
+ * population.
+ * The solution: move the Vanilla registry to another class and replace the IdRegistry
+ * reference in BlockEntityType with this one.
+ */
+public final class BlockEntityTypeIdRegistry {
+
+	public static final IdRegistry<Identifier, BlockEntityType<?>> REGISTRY = new IdRegistry<>();
+
+}

--- a/libraries/blockentities/blockentities-mc1.13-pre5-mc18w31a/src/main/java/net/ornithemc/osl/blockentities/impl/BlockEntityTypeRegistryImpl.java
+++ b/libraries/blockentities/blockentities-mc1.13-pre5-mc18w31a/src/main/java/net/ornithemc/osl/blockentities/impl/BlockEntityTypeRegistryImpl.java
@@ -1,0 +1,81 @@
+package net.ornithemc.osl.blockentities.impl;
+
+import java.util.Set;
+
+import net.minecraft.block.entity.BlockEntity;
+import net.minecraft.block.entity.BlockEntityType;
+
+import net.ornithemc.osl.blockentities.api.BlockEntityEvents;
+import net.ornithemc.osl.core.api.util.NamespacedIdentifier;
+import net.ornithemc.osl.registries.api.registry.Registry;
+import net.ornithemc.osl.registries.api.registry.RegistryKeys;
+import net.ornithemc.osl.registries.api.registry.ResourceKey;
+import net.ornithemc.osl.registries.api.registry.SyncedRegistries;
+import net.ornithemc.osl.registries.impl.registry.VanillaRegistries;
+
+public final class BlockEntityTypeRegistryImpl {
+
+	public static final Registry<BlockEntityType<?>> REGISTRY = VanillaRegistries.registerSimple(RegistryKeys.BLOCK_ENTITY_TYPE, BlockEntityTypeIdRegistry.REGISTRY, () -> BlockEntityType.REGISTRY);
+
+	private static boolean locked = true;
+
+	public static int getId(BlockEntityType<?> type) {
+		return REGISTRY.getId(type);
+	}
+
+	public static NamespacedIdentifier getIdentifier(BlockEntityType<?> type) {
+		return REGISTRY.getIdentifier(type);
+	}
+
+	public static ResourceKey<BlockEntityType<?>> getKey(BlockEntityType<?> type) {
+		return REGISTRY.getKey(type);
+	}
+
+	public static BlockEntityType<?> getBlockEntityType(int id) {
+		return REGISTRY.get(id);
+	}
+
+	public static BlockEntityType<?> getBlockEntityType(NamespacedIdentifier identifier) {
+		return REGISTRY.get(identifier);
+	}
+
+	public static BlockEntityType<?> getBlockEntityType(ResourceKey<BlockEntityType<?>> key) {
+		return REGISTRY.get(key);
+	}
+
+	public static Set<NamespacedIdentifier> identifierSet() {
+		return REGISTRY.identifierSet();
+	}
+
+	public static Set<ResourceKey<BlockEntityType<?>>> keySet() {
+		return REGISTRY.keySet();
+	}
+
+	public static <T extends BlockEntity> BlockEntityType<T> register(NamespacedIdentifier identifier, BlockEntityType.Builder<T> type) {
+		if (locked) {
+			throw new IllegalStateException("register called too early: registry locked!");
+		} else {
+			return Registry.register(REGISTRY, identifier, type.build(null));
+		}
+	}
+
+	public static <T extends BlockEntity> BlockEntityType<T> register(ResourceKey<BlockEntityType<?>> key, BlockEntityType.Builder<T> type) {
+		if (locked) {
+			throw new IllegalStateException("register called too early: registry locked!");
+		} else {
+			return Registry.register(REGISTRY, key, type.build(null));
+		}
+	}
+
+	public static void init() {
+		SyncedRegistries.register(RegistryKeys.BLOCK_ENTITY_TYPE);
+	}
+
+	public static void unlock() {
+		locked = false;
+	}
+
+	public static void registerBlockEntityTypes() {
+		BlockEntityEvents.REGISTER_BLOCK_ENTITY_TYPES.invoker().run();
+	}
+}

--- a/libraries/blockentities/blockentities-mc1.13-pre5-mc18w31a/src/main/java/net/ornithemc/osl/blockentities/impl/mixin/common/BlockEntityTypeMixin.java
+++ b/libraries/blockentities/blockentities-mc1.13-pre5-mc18w31a/src/main/java/net/ornithemc/osl/blockentities/impl/mixin/common/BlockEntityTypeMixin.java
@@ -1,0 +1,51 @@
+package net.ornithemc.osl.blockentities.impl.mixin.common;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.Redirect;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import net.minecraft.block.entity.BlockEntityType;
+import net.minecraft.resource.Identifier;
+import net.minecraft.util.registry.IdRegistry;
+
+import net.ornithemc.osl.blockentities.impl.BlockEntityTypeIdRegistry;
+import net.ornithemc.osl.blockentities.impl.BlockEntityTypeRegistryImpl;
+
+@Mixin(BlockEntityType.class)
+public class BlockEntityTypeMixin {
+
+	@Redirect(
+		method = "<clinit>",
+		at = @At(
+			value = "NEW",
+			target = "net/minecraft/util/registry/IdRegistry"
+		)
+	)
+	private static IdRegistry<Identifier, BlockEntityType<?>> osl$blockentities$replaceIdRegistry() {
+		// this allows us to register the block entity type registry in
+		// the API entrypoint without triggering a BlockEntityType class load
+		return BlockEntityTypeIdRegistry.REGISTRY;
+	}
+
+	@Inject(
+		method = "<clinit>",
+		at = @At(
+			value = "HEAD"
+		)
+	)
+	private static void osl$blockentities$unlockBlockEntityTypeRegistry(CallbackInfo ci) {
+		BlockEntityTypeRegistryImpl.unlock();
+	}
+
+	@Inject(
+		method = "<clinit>",
+		at = @At(
+			value = "TAIL"
+		)
+	)
+	private static void osl$blockentities$registerBlockEntityTypes(CallbackInfo ci) {
+		BlockEntityTypeRegistryImpl.registerBlockEntityTypes();
+	}
+}

--- a/libraries/blockentities/blockentities-mc1.13-pre5-mc18w31a/src/main/resources/fabric.mod.json
+++ b/libraries/blockentities/blockentities-mc1.13-pre5-mc18w31a/src/main/resources/fabric.mod.json
@@ -1,0 +1,37 @@
+{
+  "schemaVersion": 1,
+  "id": "osl-blockentities",
+  "version": "0.1.0+mc1.13-pre5-mc18w31a",
+  "environment": "*",
+  "entrypoints": {
+    "init": [
+      "net.ornithemc.osl.blockentities.impl.BlockEntityTypeRegistryImpl::init"
+    ]
+  },
+  "mixins": [
+    "osl.blockentities.mixins.json"
+  ],
+  "depends": {
+    "fabricloader": "\u003e\u003d0.18.0",
+    "minecraft": "\u003e\u003d1.13-rc.5 \u003c\u003d1.13.1-alpha.18.31.a",
+    "osl-core": "\u003e\u003d0.9.0",
+    "osl-entrypoints": "\u003e\u003d0.5.0",
+    "osl-lifecycle-events": "\u003e\u003d0.6.0",
+    "osl-executors": "\u003e\u003d0.1.0",
+    "osl-text-components": "\u003e\u003d0.1.0-",
+    "osl-networking": "\u003e\u003d0.10.0",
+    "osl-networking-impl": "\u003e\u003d0.2.0",
+    "osl-registries": "\u003e\u003d0.1.0"
+  },
+  "name": "OSL Block Entities",
+  "description": "Block Entities API and events.",
+  "authors": [
+    "OrnitheMC"
+  ],
+  "contact": {
+    "homepage": "https://ornithemc.net/",
+    "issues": "https://github.com/OrnitheMC/ornithe-standard-libraries/issues",
+    "sources": "https://github.com/OrnitheMC/ornithe-standard-libraries"
+  },
+  "license": "Apache-2.0"
+}

--- a/libraries/blockentities/blockentities-mc1.13-pre5-mc18w31a/src/main/resources/osl.blockentities.mixins.json
+++ b/libraries/blockentities/blockentities-mc1.13-pre5-mc18w31a/src/main/resources/osl.blockentities.mixins.json
@@ -1,0 +1,16 @@
+{
+	"required": true,
+	"minVersion": "0.8",
+	"package": "net.ornithemc.osl.blockentities.impl.mixin",
+	"compatibilityLevel": "JAVA_8",
+	"mixins": [
+		"common.BlockEntityTypeMixin"
+	],
+	"client": [
+	],
+	"server": [
+	],
+	"injectors": {
+		"defaultRequire": 1
+	}
+}

--- a/libraries/blockentities/blockentities-mc1.14.1-pre1-mc1.14.4/build.gradle
+++ b/libraries/blockentities/blockentities-mc1.14.1-pre1-mc1.14.4/build.gradle
@@ -1,0 +1,1 @@
+setUpModule(project)

--- a/libraries/blockentities/blockentities-mc1.14.1-pre1-mc1.14.4/gradle.properties
+++ b/libraries/blockentities/blockentities-mc1.14.1-pre1-mc1.14.4/gradle.properties
@@ -1,0 +1,4 @@
+min_mc_version = 1.14.1-pre1
+max_mc_version = 1.14.4
+
+minecraft_version = 1.14.4

--- a/libraries/blockentities/blockentities-mc1.14.1-pre1-mc1.14.4/src/main/java/net/ornithemc/osl/blockentities/api/BlockEntityEvents.java
+++ b/libraries/blockentities/blockentities-mc1.14.1-pre1-mc1.14.4/src/main/java/net/ornithemc/osl/blockentities/api/BlockEntityEvents.java
@@ -1,0 +1,35 @@
+package net.ornithemc.osl.blockentities.api;
+
+import net.ornithemc.osl.core.api.events.Event;
+
+/**
+ * Events related to the block entities lifecycle.
+ */
+public final class BlockEntityEvents {
+
+	/**
+	 * This event is invoked upon game start-up, after Vanilla block entity registration is finished.
+	 * 
+	 * <p>
+	 * Custom block entity type registration should be done in a listener of this event.
+	 * Helper methods for registering block entity types can be found in the {@linkplain
+	 * BlockEntityTypeRegistry} class.
+	 * 
+	 * <p>
+	 * Listeners to this event should be registered in your mod's entrypoint,
+	 * and can be done as follows:
+	 * 
+	 * <pre>
+	 * {@code
+	 * BlockEntityEvents.REGISTER_BLOCK_ENTITY_TYPES.register(() -> {
+	 * 	BlockEntityTypeRegistry.register(NamespacedIdentifiers.from("example", "cookie"), BlockEntityTypes.builder(CookieBlockEntity::new));
+	 * });
+	 * }
+	 * </pre>
+	 * 
+	 * @see BlockEntityTypeRegistry
+	 * @see BlockEntityTypes
+	 */
+	public static final Event<Runnable> REGISTER_BLOCK_ENTITY_TYPES = Event.runnable();
+
+}

--- a/libraries/blockentities/blockentities-mc1.14.1-pre1-mc1.14.4/src/main/java/net/ornithemc/osl/blockentities/api/BlockEntityTypeRegistry.java
+++ b/libraries/blockentities/blockentities-mc1.14.1-pre1-mc1.14.4/src/main/java/net/ornithemc/osl/blockentities/api/BlockEntityTypeRegistry.java
@@ -1,0 +1,95 @@
+package net.ornithemc.osl.blockentities.api;
+
+import java.util.Set;
+
+import net.minecraft.block.entity.BlockEntity;
+import net.minecraft.block.entity.BlockEntityType;
+
+import net.ornithemc.osl.blockentities.impl.BlockEntityTypeRegistryImpl;
+import net.ornithemc.osl.core.api.util.NamespacedIdentifier;
+import net.ornithemc.osl.registries.api.registry.Registry;
+import net.ornithemc.osl.registries.api.registry.ResourceKey;
+
+/**
+ * Public access to the Block Entity Types registry.
+ */
+public final class BlockEntityTypeRegistry {
+
+	public static final Registry<BlockEntityType<?>> REGISTRY = BlockEntityTypeRegistryImpl.REGISTRY;
+
+	/**
+	 * @return the numerical ID assigned to the given block entity type.
+	 */
+	public static int getId(BlockEntityType<?> type) {
+		return BlockEntityTypeRegistryImpl.getId(type);
+	}
+
+	/**
+	 * @return the namespaced ID assigned to the given block entity type.
+	 */
+	public static NamespacedIdentifier getIdentifier(BlockEntityType<?> type) {
+		return BlockEntityTypeRegistryImpl.getIdentifier(type);
+	}
+
+	/**
+	 * @return the resource key assigned to the given block entity type.
+	 */
+	public static ResourceKey<BlockEntityType<?>> getKey(BlockEntityType<?> type) {
+		return BlockEntityTypeRegistryImpl.getKey(type);
+	}
+
+	/**
+	 * @return the block entity type mapped to the given numerical ID.
+	 */
+	public static BlockEntityType<?> getBlockEntityType(int id) {
+		return BlockEntityTypeRegistryImpl.getBlockEntityType(id);
+	}
+
+	/**
+	 * @return the block entity type mapped to the given namespaced ID.
+	 */
+	public static BlockEntityType<?> getBlockEntityType(NamespacedIdentifier identifier) {
+		return BlockEntityTypeRegistryImpl.getBlockEntityType(identifier);
+	}
+
+	/**
+	 * @return the block entity type mapped to the given resource key.
+	 */
+	public static BlockEntityType<?> getBlockEntityType(ResourceKey<BlockEntityType<?>> key) {
+		return BlockEntityTypeRegistryImpl.getBlockEntityType(key);
+	}
+
+	/**
+	 * @return a set containing all namespaced IDs in the registry.
+	 */
+	public static Set<NamespacedIdentifier> identifierSet() {
+		return BlockEntityTypeRegistryImpl.identifierSet();
+	}
+
+	/**
+	 * @return a set containing all resource keys in the registry.
+	 */
+	public static Set<ResourceKey<BlockEntityType<?>>> keySet() {
+		return BlockEntityTypeRegistryImpl.keySet();
+	}
+
+	/**
+	 * @param <T>        the block entity type.
+	 * @param identifier the namespaced ID of the block entity type.
+	 * @param type       the builder for the block entity type to register.
+	 * @return the registered block entity type.
+	 */
+	public static <T extends BlockEntity> BlockEntityType<T> register(NamespacedIdentifier identifier, BlockEntityType.Builder<T> type) {
+		return BlockEntityTypeRegistryImpl.register(identifier, type);
+	}
+
+	/**
+	 * @param <T>   the block entity type.
+	 * @param key   the resource key of the block entity type.
+	 * @param type  the builder for the block entity type to register.
+	 * @return the registered block entity type.
+	 */
+	public static <T extends BlockEntity> BlockEntityType<T> register(ResourceKey<BlockEntityType<?>> key, BlockEntityType.Builder<T> type) {
+		return BlockEntityTypeRegistryImpl.register(key, type);
+	}
+}

--- a/libraries/blockentities/blockentities-mc1.14.1-pre1-mc1.14.4/src/main/java/net/ornithemc/osl/blockentities/api/BlockEntityTypes.java
+++ b/libraries/blockentities/blockentities-mc1.14.1-pre1-mc1.14.4/src/main/java/net/ornithemc/osl/blockentities/api/BlockEntityTypes.java
@@ -1,0 +1,32 @@
+package net.ornithemc.osl.blockentities.api;
+
+import java.util.function.Supplier;
+
+import net.minecraft.block.Block;
+import net.minecraft.block.entity.BlockEntity;
+import net.minecraft.block.entity.BlockEntityType;
+
+import net.ornithemc.osl.blockentities.impl.BlockEntityTypeRegistryImpl;
+
+/**
+ * Utilities for constructing and modifying block entity types.
+ */
+public final class BlockEntityTypes {
+
+	/**
+	 * @return a new block entity type builder with the given block entity factory and the given blocks.
+	 */
+	public static <T extends BlockEntity> BlockEntityType.Builder<T> builder(Supplier<? extends T> factory, Block... blocks) {
+		return BlockEntityType.Builder.m_33563020(factory, blocks);
+	}
+
+	/**
+	 * Adds the given blocks to the given block entity type.
+	 * 
+	 * @param type   the block entity type.
+	 * @param blocks the blocks to add to the block entity type.
+	 */
+	public static void addBlocks(BlockEntityType<?> type, Block... blocks) {
+		BlockEntityTypeRegistryImpl.addBlocks(type, blocks);
+	}
+}

--- a/libraries/blockentities/blockentities-mc1.14.1-pre1-mc1.14.4/src/main/java/net/ornithemc/osl/blockentities/impl/BlockEntityTypeRegistryImpl.java
+++ b/libraries/blockentities/blockentities-mc1.14.1-pre1-mc1.14.4/src/main/java/net/ornithemc/osl/blockentities/impl/BlockEntityTypeRegistryImpl.java
@@ -1,0 +1,87 @@
+package net.ornithemc.osl.blockentities.impl;
+
+import java.util.Set;
+
+import net.minecraft.block.Block;
+import net.minecraft.block.entity.BlockEntity;
+import net.minecraft.block.entity.BlockEntityType;
+
+import net.ornithemc.osl.blockentities.api.BlockEntityEvents;
+import net.ornithemc.osl.blockentities.impl.access.BlockEntityTypeAccess;
+import net.ornithemc.osl.core.api.util.NamespacedIdentifier;
+import net.ornithemc.osl.registries.api.registry.Registry;
+import net.ornithemc.osl.registries.api.registry.RegistryKeys;
+import net.ornithemc.osl.registries.api.registry.ResourceKey;
+import net.ornithemc.osl.registries.api.registry.SyncedRegistries;
+import net.ornithemc.osl.registries.impl.registry.VanillaRegistries;
+
+public final class BlockEntityTypeRegistryImpl {
+
+	public static final Registry<BlockEntityType<?>> REGISTRY = VanillaRegistries.registerSimple(RegistryKeys.BLOCK_ENTITY_TYPE, net.minecraft.util.registry.Registry.BLOCK_ENTITY_TYPE);
+
+	private static boolean locked = true;
+
+	public static int getId(BlockEntityType<?> type) {
+		return REGISTRY.getId(type);
+	}
+
+	public static NamespacedIdentifier getIdentifier(BlockEntityType<?> type) {
+		return REGISTRY.getIdentifier(type);
+	}
+
+	public static ResourceKey<BlockEntityType<?>> getKey(BlockEntityType<?> type) {
+		return REGISTRY.getKey(type);
+	}
+
+	public static BlockEntityType<?> getBlockEntityType(int id) {
+		return REGISTRY.get(id);
+	}
+
+	public static BlockEntityType<?> getBlockEntityType(NamespacedIdentifier identifier) {
+		return REGISTRY.get(identifier);
+	}
+
+	public static BlockEntityType<?> getBlockEntityType(ResourceKey<BlockEntityType<?>> key) {
+		return REGISTRY.get(key);
+	}
+
+	public static Set<NamespacedIdentifier> identifierSet() {
+		return REGISTRY.identifierSet();
+	}
+
+	public static Set<ResourceKey<BlockEntityType<?>>> keySet() {
+		return REGISTRY.keySet();
+	}
+
+	public static <T extends BlockEntity> BlockEntityType<T> register(NamespacedIdentifier identifier, BlockEntityType.Builder<T> type) {
+		if (locked) {
+			throw new IllegalStateException("register called too early: registry locked!");
+		} else {
+			return Registry.register(REGISTRY, identifier, type.build(null));
+		}
+	}
+
+	public static <T extends BlockEntity> BlockEntityType<T> register(ResourceKey<BlockEntityType<?>> key, BlockEntityType.Builder<T> type) {
+		if (locked) {
+			throw new IllegalStateException("register called too early: registry locked!");
+		} else {
+			return Registry.register(REGISTRY, key, type.build(null));
+		}
+	}
+
+	public static void addBlocks(BlockEntityType<?> type, Block... blocks) {
+		((BlockEntityTypeAccess) type).osl$blockentities$addBlocks(blocks);
+	}
+
+	public static void init() {
+		SyncedRegistries.register(RegistryKeys.BLOCK_ENTITY_TYPE);
+	}
+
+	public static void unlock() {
+		locked = false;
+	}
+
+	public static void registerBlockEntityTypes() {
+		BlockEntityEvents.REGISTER_BLOCK_ENTITY_TYPES.invoker().run();
+	}
+}

--- a/libraries/blockentities/blockentities-mc1.14.1-pre1-mc1.14.4/src/main/java/net/ornithemc/osl/blockentities/impl/access/BlockEntityTypeAccess.java
+++ b/libraries/blockentities/blockentities-mc1.14.1-pre1-mc1.14.4/src/main/java/net/ornithemc/osl/blockentities/impl/access/BlockEntityTypeAccess.java
@@ -1,0 +1,9 @@
+package net.ornithemc.osl.blockentities.impl.access;
+
+import net.minecraft.block.Block;
+
+public interface BlockEntityTypeAccess {
+
+	void osl$blockentities$addBlocks(Block... blocks);
+
+}

--- a/libraries/blockentities/blockentities-mc1.14.1-pre1-mc1.14.4/src/main/java/net/ornithemc/osl/blockentities/impl/mixin/common/BlockEntityTypeMixin.java
+++ b/libraries/blockentities/blockentities-mc1.14.1-pre1-mc1.14.4/src/main/java/net/ornithemc/osl/blockentities/impl/mixin/common/BlockEntityTypeMixin.java
@@ -1,0 +1,67 @@
+package net.ornithemc.osl.blockentities.impl.mixin.common;
+
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.At.Shift;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import net.minecraft.block.Block;
+import net.minecraft.block.entity.BlockEntityType;
+
+import net.ornithemc.osl.blockentities.impl.BlockEntityTypeRegistryImpl;
+import net.ornithemc.osl.blockentities.impl.access.BlockEntityTypeAccess;
+
+@Mixin(BlockEntityType.class)
+public class BlockEntityTypeMixin implements BlockEntityTypeAccess {
+
+	@Shadow @Final
+	private Set<Block> f_11977594;
+
+	@Inject(
+		method = "<clinit>",
+		at = @At(
+			value = "HEAD"
+		)
+	)
+	private static void osl$blockentities$unlockBlockEntityTypeRegistry(CallbackInfo ci) {
+		BlockEntityTypeRegistryImpl.unlock();
+	}
+
+	@Inject(
+		method = "<clinit>",
+		at = @At(
+			value = "TAIL"
+		)
+	)
+	private static void osl$blockentities$registerBlockEntityTypes(CallbackInfo ci) {
+		BlockEntityTypeRegistryImpl.registerBlockEntityTypes();
+	}
+
+	@ModifyVariable(
+		method = "<init>",
+		argsOnly = true,
+		at = @At(
+			value = "INVOKE",
+			target = "Ljava/lang/Object;<init>()V",
+			shift = Shift.AFTER
+		)
+	)
+	private Set<Block> osl$blockentities$makeBlocksSetModifiable(Set<Block> blocks) {
+		// Vanilla's Builder uses Google Commons' ImmutableSet.of(...) which preserves order!
+		return new LinkedHashSet<>(blocks);
+	}
+
+	@Override
+	public void osl$blockentities$addBlocks(Block... blocks) {
+		for (Block block : blocks) {
+			this.f_11977594.add(block);
+		}
+	}
+}

--- a/libraries/blockentities/blockentities-mc1.14.1-pre1-mc1.14.4/src/main/resources/fabric.mod.json
+++ b/libraries/blockentities/blockentities-mc1.14.1-pre1-mc1.14.4/src/main/resources/fabric.mod.json
@@ -1,0 +1,37 @@
+{
+  "schemaVersion": 1,
+  "id": "osl-blockentities",
+  "version": "0.1.0+mc1.14.1-pre1-mc1.14.4",
+  "environment": "*",
+  "entrypoints": {
+    "init": [
+      "net.ornithemc.osl.blockentities.impl.BlockEntityTypeRegistryImpl::init"
+    ]
+  },
+  "mixins": [
+    "osl.blockentities.mixins.json"
+  ],
+  "depends": {
+    "fabricloader": "\u003e\u003d0.18.0",
+    "minecraft": "\u003e\u003d1.14.1-rc.1 \u003c\u003d1.14.4",
+    "osl-core": "\u003e\u003d0.9.0",
+    "osl-entrypoints": "\u003e\u003d0.5.0",
+    "osl-lifecycle-events": "\u003e\u003d0.6.0",
+    "osl-executors": "\u003e\u003d0.1.0",
+    "osl-text-components": "\u003e\u003d0.1.0-",
+    "osl-networking": "\u003e\u003d0.10.0",
+    "osl-networking-impl": "\u003e\u003d0.2.0",
+    "osl-registries": "\u003e\u003d0.1.0"
+  },
+  "name": "OSL Block Entities",
+  "description": "Block Entities API and events.",
+  "authors": [
+    "OrnitheMC"
+  ],
+  "contact": {
+    "homepage": "https://ornithemc.net/",
+    "issues": "https://github.com/OrnitheMC/ornithe-standard-libraries/issues",
+    "sources": "https://github.com/OrnitheMC/ornithe-standard-libraries"
+  },
+  "license": "Apache-2.0"
+}

--- a/libraries/blockentities/blockentities-mc1.14.1-pre1-mc1.14.4/src/main/resources/osl.blockentities.mixins.json
+++ b/libraries/blockentities/blockentities-mc1.14.1-pre1-mc1.14.4/src/main/resources/osl.blockentities.mixins.json
@@ -1,0 +1,16 @@
+{
+	"required": true,
+	"minVersion": "0.8",
+	"package": "net.ornithemc.osl.blockentities.impl.mixin",
+	"compatibilityLevel": "JAVA_8",
+	"mixins": [
+		"common.BlockEntityTypeMixin"
+	],
+	"client": [
+	],
+	"server": [
+	],
+	"injectors": {
+		"defaultRequire": 1
+	}
+}

--- a/libraries/blockentities/blockentities-mc16w32a-mc18w01a/build.gradle
+++ b/libraries/blockentities/blockentities-mc16w32a-mc18w01a/build.gradle
@@ -1,0 +1,1 @@
+setUpModule(project)

--- a/libraries/blockentities/blockentities-mc16w32a-mc18w01a/gradle.properties
+++ b/libraries/blockentities/blockentities-mc16w32a-mc18w01a/gradle.properties
@@ -1,0 +1,6 @@
+min_mc_version = 16w32a
+max_mc_version = 18w01a
+
+minecraft_version = 1.12.2
+raven_build = 1
+sparrow_build = 1

--- a/libraries/blockentities/blockentities-mc16w32a-mc18w01a/src/main/java/net/ornithemc/osl/blockentities/api/BlockEntityEvents.java
+++ b/libraries/blockentities/blockentities-mc16w32a-mc18w01a/src/main/java/net/ornithemc/osl/blockentities/api/BlockEntityEvents.java
@@ -1,0 +1,34 @@
+package net.ornithemc.osl.blockentities.api;
+
+import net.ornithemc.osl.core.api.events.Event;
+
+/**
+ * Events related to the block entities lifecycle.
+ */
+public final class BlockEntityEvents {
+
+	/**
+	 * This event is invoked upon game start-up, after Vanilla block entity registration is finished.
+	 * 
+	 * <p>
+	 * Custom block entity type registration should be done in a listener of this event.
+	 * Helper methods for registering block entity types can be found in the {@linkplain
+	 * BlockEntityTypeRegistry} class.
+	 * 
+	 * <p>
+	 * Listeners to this event should be registered in your mod's entrypoint,
+	 * and can be done as follows:
+	 * 
+	 * <pre>
+	 * {@code
+	 * BlockEntityEvents.REGISTER_BLOCK_ENTITY_TYPES.register(() -> {
+	 * 	BlockEntityTypeRegistry.register(NamespacedIdentifiers.from("example", "cookie"), CookieBlockEntity.class);
+	 * });
+	 * }
+	 * </pre>
+	 * 
+	 * @see BlockEntityTypeRegistry
+	 */
+	public static final Event<Runnable> REGISTER_BLOCK_ENTITY_TYPES = Event.runnable();
+
+}

--- a/libraries/blockentities/blockentities-mc16w32a-mc18w01a/src/main/java/net/ornithemc/osl/blockentities/api/BlockEntityTypeRegistry.java
+++ b/libraries/blockentities/blockentities-mc16w32a-mc18w01a/src/main/java/net/ornithemc/osl/blockentities/api/BlockEntityTypeRegistry.java
@@ -1,0 +1,94 @@
+package net.ornithemc.osl.blockentities.api;
+
+import java.util.Set;
+
+import net.minecraft.block.entity.BlockEntity;
+
+import net.ornithemc.osl.blockentities.impl.BlockEntityTypeRegistryImpl;
+import net.ornithemc.osl.core.api.util.NamespacedIdentifier;
+import net.ornithemc.osl.registries.api.registry.Registry;
+import net.ornithemc.osl.registries.api.registry.ResourceKey;
+
+/**
+ * Public access to the Block Entity Types registry.
+ */
+public final class BlockEntityTypeRegistry {
+
+	public static final Registry<Class<? extends BlockEntity>> REGISTRY = BlockEntityTypeRegistryImpl.REGISTRY;
+
+	/**
+	 * @return the numerical ID assigned to the given block entity type.
+	 */
+	public static int getId(Class<? extends BlockEntity> type) {
+		return BlockEntityTypeRegistryImpl.getId(type);
+	}
+
+	/**
+	 * @return the namespaced ID assigned to the given block entity type.
+	 */
+	public static NamespacedIdentifier getIdentifier(Class<? extends BlockEntity> type) {
+		return BlockEntityTypeRegistryImpl.getIdentifier(type);
+	}
+
+	/**
+	 * @return the resource key assigned to the given block entity type.
+	 */
+	public static ResourceKey<Class<? extends BlockEntity>> getKey(Class<? extends BlockEntity> type) {
+		return BlockEntityTypeRegistryImpl.getKey(type);
+	}
+
+	/**
+	 * @return the block entity type mapped to the given numerical ID.
+	 */
+	public static Class<? extends BlockEntity> getBlockEntityType(int id) {
+		return BlockEntityTypeRegistryImpl.getBlockEntityType(id);
+	}
+
+	/**
+	 * @return the block entity type mapped to the given namespaced ID.
+	 */
+	public static Class<? extends BlockEntity> getBlockEntityType(NamespacedIdentifier identifier) {
+		return BlockEntityTypeRegistryImpl.getBlockEntityType(identifier);
+	}
+
+	/**
+	 * @return the block entity type mapped to the given resource key.
+	 */
+	public static Class<? extends BlockEntity> getBlockEntityType(ResourceKey<Class<? extends BlockEntity>> key) {
+		return BlockEntityTypeRegistryImpl.getBlockEntityType(key);
+	}
+
+	/**
+	 * @return a set containing all namespaced IDs in the registry.
+	 */
+	public static Set<NamespacedIdentifier> identifierSet() {
+		return BlockEntityTypeRegistryImpl.identifierSet();
+	}
+
+	/**
+	 * @return a set containing all resource keys in the registry.
+	 */
+	public static Set<ResourceKey<Class<? extends BlockEntity>>> keySet() {
+		return BlockEntityTypeRegistryImpl.keySet();
+	}
+
+	/**
+	 * @param <T>        the block entity type.
+	 * @param identifier the namespaced ID of the block entity type.
+	 * @param type       the block entity type to register.
+	 * @return the registered block entity type.
+	 */
+	public static <T extends BlockEntity> Class<T> register(NamespacedIdentifier identifier, Class<T> type) {
+		return BlockEntityTypeRegistryImpl.register(identifier, type);
+	}
+
+	/**
+	 * @param <T>   the block entity type.
+	 * @param key   the resource key of the block entity type.
+	 * @param type  the block entity type to register.
+	 * @return the registered block entity type.
+	 */
+	public static <T extends BlockEntity> Class<T> register(ResourceKey<Class<? extends BlockEntity>> key, Class<T> type) {
+		return BlockEntityTypeRegistryImpl.register(key, type);
+	}
+}

--- a/libraries/blockentities/blockentities-mc16w32a-mc18w01a/src/main/java/net/ornithemc/osl/blockentities/impl/BlockEntityTypeIdRegistry.java
+++ b/libraries/blockentities/blockentities-mc16w32a-mc18w01a/src/main/java/net/ornithemc/osl/blockentities/impl/BlockEntityTypeIdRegistry.java
@@ -1,0 +1,20 @@
+package net.ornithemc.osl.blockentities.impl;
+
+import net.minecraft.block.entity.BlockEntity;
+import net.minecraft.resource.Identifier;
+import net.minecraft.util.registry.IdRegistry;
+
+/**
+ * The block entity type registry is created and populated in BlockEntity's class initializer.
+ * This breaks OSL's usual pattern of registering the registry in the API entrypoint but
+ * triggering registry population during bootstrapping, since OSL has to wrap the Vanilla
+ * registry which is not possible without triggering BlockEntity class load and registry
+ * population.
+ * The solution: move the Vanilla registry to another class and replace the IdRegistry
+ * reference in BlockEntity with this one.
+ */
+public final class BlockEntityTypeIdRegistry {
+
+	public static final IdRegistry<Identifier, Class<? extends BlockEntity>> REGISTRY = new IdRegistry<>();
+
+}

--- a/libraries/blockentities/blockentities-mc16w32a-mc18w01a/src/main/java/net/ornithemc/osl/blockentities/impl/BlockEntityTypeRegistryImpl.java
+++ b/libraries/blockentities/blockentities-mc16w32a-mc18w01a/src/main/java/net/ornithemc/osl/blockentities/impl/BlockEntityTypeRegistryImpl.java
@@ -1,0 +1,80 @@
+package net.ornithemc.osl.blockentities.impl;
+
+import java.util.Set;
+
+import net.minecraft.block.entity.BlockEntity;
+
+import net.ornithemc.osl.blockentities.api.BlockEntityEvents;
+import net.ornithemc.osl.core.api.util.NamespacedIdentifier;
+import net.ornithemc.osl.registries.api.registry.Registry;
+import net.ornithemc.osl.registries.api.registry.RegistryKeys;
+import net.ornithemc.osl.registries.api.registry.ResourceKey;
+import net.ornithemc.osl.registries.api.registry.SyncedRegistries;
+import net.ornithemc.osl.registries.impl.registry.VanillaRegistries;
+
+public final class BlockEntityTypeRegistryImpl {
+
+	public static final Registry<Class<? extends BlockEntity>> REGISTRY = VanillaRegistries.registerSimple(RegistryKeys.BLOCK_ENTITY_TYPE, BlockEntityTypeIdRegistry.REGISTRY, () -> BlockEntity.REGISTRY);
+
+	private static boolean locked = true;
+
+	public static int getId(Class<? extends BlockEntity> type) {
+		return REGISTRY.getId(type);
+	}
+
+	public static NamespacedIdentifier getIdentifier(Class<? extends BlockEntity> type) {
+		return REGISTRY.getIdentifier(type);
+	}
+
+	public static ResourceKey<Class<? extends BlockEntity>> getKey(Class<? extends BlockEntity> type) {
+		return REGISTRY.getKey(type);
+	}
+
+	public static Class<? extends BlockEntity> getBlockEntityType(int id) {
+		return REGISTRY.get(id);
+	}
+
+	public static Class<? extends BlockEntity> getBlockEntityType(NamespacedIdentifier identifier) {
+		return REGISTRY.get(identifier);
+	}
+
+	public static Class<? extends BlockEntity> getBlockEntityType(ResourceKey<Class<? extends BlockEntity>> key) {
+		return REGISTRY.get(key);
+	}
+
+	public static Set<NamespacedIdentifier> identifierSet() {
+		return REGISTRY.identifierSet();
+	}
+
+	public static Set<ResourceKey<Class<? extends BlockEntity>>> keySet() {
+		return REGISTRY.keySet();
+	}
+
+	public static <T extends BlockEntity> Class<T> register(NamespacedIdentifier identifier, Class<T> type) {
+		if (locked) {
+			throw new IllegalStateException("register called too early: registry locked!");
+		} else {
+			return Registry.register(REGISTRY, identifier, type);
+		}
+	}
+
+	public static <T extends BlockEntity> Class<T> register(ResourceKey<Class<? extends BlockEntity>> key, Class<T> type) {
+		if (locked) {
+			throw new IllegalStateException("register called too early: registry locked!");
+		} else {
+			return Registry.register(REGISTRY, key, type);
+		}
+	}
+
+	public static void init() {
+		SyncedRegistries.register(RegistryKeys.BLOCK_ENTITY_TYPE);
+	}
+
+	public static void unlock() {
+		locked = false;
+	}
+
+	public static void registerBlockEntityTypes() {
+		BlockEntityEvents.REGISTER_BLOCK_ENTITY_TYPES.invoker().run();
+	}
+}

--- a/libraries/blockentities/blockentities-mc16w32a-mc18w01a/src/main/java/net/ornithemc/osl/blockentities/impl/mixin/common/BlockEntityMixin.java
+++ b/libraries/blockentities/blockentities-mc16w32a-mc18w01a/src/main/java/net/ornithemc/osl/blockentities/impl/mixin/common/BlockEntityMixin.java
@@ -1,0 +1,51 @@
+package net.ornithemc.osl.blockentities.impl.mixin.common;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.Redirect;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import net.minecraft.block.entity.BlockEntity;
+import net.minecraft.resource.Identifier;
+import net.minecraft.util.registry.IdRegistry;
+
+import net.ornithemc.osl.blockentities.impl.BlockEntityTypeIdRegistry;
+import net.ornithemc.osl.blockentities.impl.BlockEntityTypeRegistryImpl;
+
+@Mixin(BlockEntity.class)
+public class BlockEntityMixin {
+
+	@Redirect(
+		method = "<clinit>",
+		at = @At(
+			value = "NEW",
+			target = "net/minecraft/util/registry/IdRegistry"
+		)
+	)
+	private static IdRegistry<Identifier, Class<? extends BlockEntity>> osl$blockentities$replaceIdRegistry() {
+		// this allows us to register the block entity type registry in
+		// the API entrypoint without triggering a BlockEntity class load
+		return BlockEntityTypeIdRegistry.REGISTRY;
+	}
+
+	@Inject(
+		method = "<clinit>",
+		at = @At(
+			value = "HEAD"
+		)
+	)
+	private static void osl$blockentities$unlockBlockEntityTypeRegistry(CallbackInfo ci) {
+		BlockEntityTypeRegistryImpl.unlock();
+	}
+
+	@Inject(
+		method = "<clinit>",
+		at = @At(
+			value = "TAIL"
+		)
+	)
+	private static void osl$blockentities$registerBlockEntityTypes(CallbackInfo ci) {
+		BlockEntityTypeRegistryImpl.registerBlockEntityTypes();
+	}
+}

--- a/libraries/blockentities/blockentities-mc16w32a-mc18w01a/src/main/resources/fabric.mod.json
+++ b/libraries/blockentities/blockentities-mc16w32a-mc18w01a/src/main/resources/fabric.mod.json
@@ -1,0 +1,38 @@
+{
+  "schemaVersion": 1,
+  "id": "osl-blockentities",
+  "version": "0.1.0+mc16w32a-mc18w01a",
+  "environment": "*",
+  "entrypoints": {
+    "init": [
+      "net.ornithemc.osl.blockentities.impl.BlockEntityTypeRegistryImpl::init"
+    ]
+  },
+  "mixins": [
+    "osl.blockentities.mixins.json"
+  ],
+  "accessWidener": "osl.blockentities.classtweaker",
+  "depends": {
+    "fabricloader": "\u003e\u003d0.18.0",
+    "minecraft": "\u003e\u003d1.11-alpha.16.32.a \u003c\u003d1.13-alpha.18.1.a",
+    "osl-core": "\u003e\u003d0.9.0",
+    "osl-entrypoints": "\u003e\u003d0.5.0",
+    "osl-lifecycle-events": "\u003e\u003d0.6.0",
+    "osl-executors": "\u003e\u003d0.1.0",
+    "osl-text-components": "\u003e\u003d0.1.0-",
+    "osl-networking": "\u003e\u003d0.10.0",
+    "osl-networking-impl": "\u003e\u003d0.2.0",
+    "osl-registries": "\u003e\u003d0.1.0"
+  },
+  "name": "OSL Block Entities",
+  "description": "Block Entities API and events.",
+  "authors": [
+    "OrnitheMC"
+  ],
+  "contact": {
+    "homepage": "https://ornithemc.net/",
+    "issues": "https://github.com/OrnitheMC/ornithe-standard-libraries/issues",
+    "sources": "https://github.com/OrnitheMC/ornithe-standard-libraries"
+  },
+  "license": "Apache-2.0"
+}

--- a/libraries/blockentities/blockentities-mc16w32a-mc18w01a/src/main/resources/osl.blockentities.classtweaker
+++ b/libraries/blockentities/blockentities-mc16w32a-mc18w01a/src/main/resources/osl.blockentities.classtweaker
@@ -1,0 +1,3 @@
+classTweaker	v1	named
+
+accessible	field	net/minecraft/block/entity/BlockEntity	REGISTRY	Lnet/minecraft/util/registry/IdRegistry;

--- a/libraries/blockentities/blockentities-mc16w32a-mc18w01a/src/main/resources/osl.blockentities.mixins.json
+++ b/libraries/blockentities/blockentities-mc16w32a-mc18w01a/src/main/resources/osl.blockentities.mixins.json
@@ -1,0 +1,16 @@
+{
+	"required": true,
+	"minVersion": "0.8",
+	"package": "net.ornithemc.osl.blockentities.impl.mixin",
+	"compatibilityLevel": "JAVA_8",
+	"mixins": [
+		"common.BlockEntityMixin"
+	],
+	"client": [
+	],
+	"server": [
+	],
+	"injectors": {
+		"defaultRequire": 1
+	}
+}

--- a/libraries/blockentities/blockentities-mc18w32a-mc1.14/build.gradle
+++ b/libraries/blockentities/blockentities-mc18w32a-mc1.14/build.gradle
@@ -1,0 +1,1 @@
+setUpModule(project)

--- a/libraries/blockentities/blockentities-mc18w32a-mc1.14/gradle.properties
+++ b/libraries/blockentities/blockentities-mc18w32a-mc1.14/gradle.properties
@@ -1,0 +1,4 @@
+min_mc_version = 18w32a
+max_mc_version = 1.14
+
+minecraft_version = 1.13.2

--- a/libraries/blockentities/blockentities-mc18w32a-mc1.14/src/main/java/net/ornithemc/osl/blockentities/api/BlockEntityEvents.java
+++ b/libraries/blockentities/blockentities-mc18w32a-mc1.14/src/main/java/net/ornithemc/osl/blockentities/api/BlockEntityEvents.java
@@ -1,0 +1,35 @@
+package net.ornithemc.osl.blockentities.api;
+
+import net.ornithemc.osl.core.api.events.Event;
+
+/**
+ * Events related to the block entities lifecycle.
+ */
+public final class BlockEntityEvents {
+
+	/**
+	 * This event is invoked upon game start-up, after Vanilla block entity registration is finished.
+	 * 
+	 * <p>
+	 * Custom block entity type registration should be done in a listener of this event.
+	 * Helper methods for registering block entity types can be found in the {@linkplain
+	 * BlockEntityTypeRegistry} class.
+	 * 
+	 * <p>
+	 * Listeners to this event should be registered in your mod's entrypoint,
+	 * and can be done as follows:
+	 * 
+	 * <pre>
+	 * {@code
+	 * BlockEntityEvents.REGISTER_BLOCK_ENTITY_TYPES.register(() -> {
+	 * 	BlockEntityTypeRegistry.register(NamespacedIdentifiers.from("example", "cookie"), BlockEntityTypes.builder(CookieBlockEntity::new));
+	 * });
+	 * }
+	 * </pre>
+	 * 
+	 * @see BlockEntityTypeRegistry
+	 * @see BlockEntityTypes
+	 */
+	public static final Event<Runnable> REGISTER_BLOCK_ENTITY_TYPES = Event.runnable();
+
+}

--- a/libraries/blockentities/blockentities-mc18w32a-mc1.14/src/main/java/net/ornithemc/osl/blockentities/api/BlockEntityTypeRegistry.java
+++ b/libraries/blockentities/blockentities-mc18w32a-mc1.14/src/main/java/net/ornithemc/osl/blockentities/api/BlockEntityTypeRegistry.java
@@ -1,0 +1,95 @@
+package net.ornithemc.osl.blockentities.api;
+
+import java.util.Set;
+
+import net.minecraft.block.entity.BlockEntity;
+import net.minecraft.block.entity.BlockEntityType;
+
+import net.ornithemc.osl.blockentities.impl.BlockEntityTypeRegistryImpl;
+import net.ornithemc.osl.core.api.util.NamespacedIdentifier;
+import net.ornithemc.osl.registries.api.registry.Registry;
+import net.ornithemc.osl.registries.api.registry.ResourceKey;
+
+/**
+ * Public access to the Block Entity Types registry.
+ */
+public final class BlockEntityTypeRegistry {
+
+	public static final Registry<BlockEntityType<?>> REGISTRY = BlockEntityTypeRegistryImpl.REGISTRY;
+
+	/**
+	 * @return the numerical ID assigned to the given block entity type.
+	 */
+	public static int getId(BlockEntityType<?> type) {
+		return BlockEntityTypeRegistryImpl.getId(type);
+	}
+
+	/**
+	 * @return the namespaced ID assigned to the given block entity type.
+	 */
+	public static NamespacedIdentifier getIdentifier(BlockEntityType<?> type) {
+		return BlockEntityTypeRegistryImpl.getIdentifier(type);
+	}
+
+	/**
+	 * @return the resource key assigned to the given block entity type.
+	 */
+	public static ResourceKey<BlockEntityType<?>> getKey(BlockEntityType<?> type) {
+		return BlockEntityTypeRegistryImpl.getKey(type);
+	}
+
+	/**
+	 * @return the block entity type mapped to the given numerical ID.
+	 */
+	public static BlockEntityType<?> getBlockEntityType(int id) {
+		return BlockEntityTypeRegistryImpl.getBlockEntityType(id);
+	}
+
+	/**
+	 * @return the block entity type mapped to the given namespaced ID.
+	 */
+	public static BlockEntityType<?> getBlockEntityType(NamespacedIdentifier identifier) {
+		return BlockEntityTypeRegistryImpl.getBlockEntityType(identifier);
+	}
+
+	/**
+	 * @return the block entity type mapped to the given resource key.
+	 */
+	public static BlockEntityType<?> getBlockEntityType(ResourceKey<BlockEntityType<?>> key) {
+		return BlockEntityTypeRegistryImpl.getBlockEntityType(key);
+	}
+
+	/**
+	 * @return a set containing all namespaced IDs in the registry.
+	 */
+	public static Set<NamespacedIdentifier> identifierSet() {
+		return BlockEntityTypeRegistryImpl.identifierSet();
+	}
+
+	/**
+	 * @return a set containing all resource keys in the registry.
+	 */
+	public static Set<ResourceKey<BlockEntityType<?>>> keySet() {
+		return BlockEntityTypeRegistryImpl.keySet();
+	}
+
+	/**
+	 * @param <T>        the block entity type.
+	 * @param identifier the namespaced ID of the block entity type.
+	 * @param type       the builder for the block entity type to register.
+	 * @return the registered block entity type.
+	 */
+	public static <T extends BlockEntity> BlockEntityType<T> register(NamespacedIdentifier identifier, BlockEntityType.Builder<T> type) {
+		return BlockEntityTypeRegistryImpl.register(identifier, type);
+	}
+
+	/**
+	 * @param <T>   the block entity type.
+	 * @param key   the resource key of the block entity type.
+	 * @param type  the builder for the block entity type to register.
+	 * @return the registered block entity type.
+	 */
+	public static <T extends BlockEntity> BlockEntityType<T> register(ResourceKey<BlockEntityType<?>> key, BlockEntityType.Builder<T> type) {
+		return BlockEntityTypeRegistryImpl.register(key, type);
+	}
+}

--- a/libraries/blockentities/blockentities-mc18w32a-mc1.14/src/main/java/net/ornithemc/osl/blockentities/api/BlockEntityTypes.java
+++ b/libraries/blockentities/blockentities-mc18w32a-mc1.14/src/main/java/net/ornithemc/osl/blockentities/api/BlockEntityTypes.java
@@ -1,0 +1,19 @@
+package net.ornithemc.osl.blockentities.api;
+
+import java.util.function.Supplier;
+
+import net.minecraft.block.entity.BlockEntity;
+import net.minecraft.block.entity.BlockEntityType;
+
+/**
+ * Utilities for constructing and modifying block entity types.
+ */
+public final class BlockEntityTypes {
+
+	/**
+	 * @return a new block entity type builder with the given block entity factory.
+	 */
+	public static <T extends BlockEntity> BlockEntityType.Builder<T> builder(Supplier<? extends T> factory) {
+		return BlockEntityType.Builder.of(factory);
+	}
+}

--- a/libraries/blockentities/blockentities-mc18w32a-mc1.14/src/main/java/net/ornithemc/osl/blockentities/impl/BlockEntityTypeRegistryImpl.java
+++ b/libraries/blockentities/blockentities-mc18w32a-mc1.14/src/main/java/net/ornithemc/osl/blockentities/impl/BlockEntityTypeRegistryImpl.java
@@ -1,0 +1,81 @@
+package net.ornithemc.osl.blockentities.impl;
+
+import java.util.Set;
+
+import net.minecraft.block.entity.BlockEntity;
+import net.minecraft.block.entity.BlockEntityType;
+
+import net.ornithemc.osl.blockentities.api.BlockEntityEvents;
+import net.ornithemc.osl.core.api.util.NamespacedIdentifier;
+import net.ornithemc.osl.registries.api.registry.Registry;
+import net.ornithemc.osl.registries.api.registry.RegistryKeys;
+import net.ornithemc.osl.registries.api.registry.ResourceKey;
+import net.ornithemc.osl.registries.api.registry.SyncedRegistries;
+import net.ornithemc.osl.registries.impl.registry.VanillaRegistries;
+
+public final class BlockEntityTypeRegistryImpl {
+
+	public static final Registry<BlockEntityType<?>> REGISTRY = VanillaRegistries.registerSimple(RegistryKeys.BLOCK_ENTITY_TYPE, net.minecraft.util.registry.Registry.BLOCK_ENTITY_TYPE);
+
+	private static boolean locked = true;
+
+	public static int getId(BlockEntityType<?> type) {
+		return REGISTRY.getId(type);
+	}
+
+	public static NamespacedIdentifier getIdentifier(BlockEntityType<?> type) {
+		return REGISTRY.getIdentifier(type);
+	}
+
+	public static ResourceKey<BlockEntityType<?>> getKey(BlockEntityType<?> type) {
+		return REGISTRY.getKey(type);
+	}
+
+	public static BlockEntityType<?> getBlockEntityType(int id) {
+		return REGISTRY.get(id);
+	}
+
+	public static BlockEntityType<?> getBlockEntityType(NamespacedIdentifier identifier) {
+		return REGISTRY.get(identifier);
+	}
+
+	public static BlockEntityType<?> getBlockEntityType(ResourceKey<BlockEntityType<?>> key) {
+		return REGISTRY.get(key);
+	}
+
+	public static Set<NamespacedIdentifier> identifierSet() {
+		return REGISTRY.identifierSet();
+	}
+
+	public static Set<ResourceKey<BlockEntityType<?>>> keySet() {
+		return REGISTRY.keySet();
+	}
+
+	public static <T extends BlockEntity> BlockEntityType<T> register(NamespacedIdentifier identifier, BlockEntityType.Builder<T> type) {
+		if (locked) {
+			throw new IllegalStateException("register called too early: registry locked!");
+		} else {
+			return Registry.register(REGISTRY, identifier, type.build(null));
+		}
+	}
+
+	public static <T extends BlockEntity> BlockEntityType<T> register(ResourceKey<BlockEntityType<?>> key, BlockEntityType.Builder<T> type) {
+		if (locked) {
+			throw new IllegalStateException("register called too early: registry locked!");
+		} else {
+			return Registry.register(REGISTRY, key, type.build(null));
+		}
+	}
+
+	public static void init() {
+		SyncedRegistries.register(RegistryKeys.BLOCK_ENTITY_TYPE);
+	}
+
+	public static void unlock() {
+		locked = false;
+	}
+
+	public static void registerBlockEntityTypes() {
+		BlockEntityEvents.REGISTER_BLOCK_ENTITY_TYPES.invoker().run();
+	}
+}

--- a/libraries/blockentities/blockentities-mc18w32a-mc1.14/src/main/java/net/ornithemc/osl/blockentities/impl/mixin/common/BlockEntityTypeMixin.java
+++ b/libraries/blockentities/blockentities-mc18w32a-mc1.14/src/main/java/net/ornithemc/osl/blockentities/impl/mixin/common/BlockEntityTypeMixin.java
@@ -1,0 +1,34 @@
+package net.ornithemc.osl.blockentities.impl.mixin.common;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import net.minecraft.block.entity.BlockEntityType;
+
+import net.ornithemc.osl.blockentities.impl.BlockEntityTypeRegistryImpl;
+
+@Mixin(BlockEntityType.class)
+public class BlockEntityTypeMixin {
+
+	@Inject(
+		method = "<clinit>",
+		at = @At(
+			value = "HEAD"
+		)
+	)
+	private static void osl$blockentities$unlockBlockEntityTypeRegistry(CallbackInfo ci) {
+		BlockEntityTypeRegistryImpl.unlock();
+	}
+
+	@Inject(
+		method = "<clinit>",
+		at = @At(
+			value = "TAIL"
+		)
+	)
+	private static void osl$blockentities$registerBlockEntityTypes(CallbackInfo ci) {
+		BlockEntityTypeRegistryImpl.registerBlockEntityTypes();
+	}
+}

--- a/libraries/blockentities/blockentities-mc18w32a-mc1.14/src/main/resources/fabric.mod.json
+++ b/libraries/blockentities/blockentities-mc18w32a-mc1.14/src/main/resources/fabric.mod.json
@@ -1,0 +1,37 @@
+{
+  "schemaVersion": 1,
+  "id": "osl-blockentities",
+  "version": "0.1.0+mc18w32a-mc1.14",
+  "environment": "*",
+  "entrypoints": {
+    "init": [
+      "net.ornithemc.osl.blockentities.impl.BlockEntityTypeRegistryImpl::init"
+    ]
+  },
+  "mixins": [
+    "osl.blockentities.mixins.json"
+  ],
+  "depends": {
+    "fabricloader": "\u003e\u003d0.18.0",
+    "minecraft": "\u003e\u003d1.13.1-alpha.18.32.a \u003c\u003d1.14",
+    "osl-core": "\u003e\u003d0.9.0",
+    "osl-entrypoints": "\u003e\u003d0.5.0",
+    "osl-lifecycle-events": "\u003e\u003d0.6.0",
+    "osl-executors": "\u003e\u003d0.1.0",
+    "osl-text-components": "\u003e\u003d0.1.0-",
+    "osl-networking": "\u003e\u003d0.10.0",
+    "osl-networking-impl": "\u003e\u003d0.2.0",
+    "osl-registries": "\u003e\u003d0.1.0"
+  },
+  "name": "OSL Block Entities",
+  "description": "Block Entities API and events.",
+  "authors": [
+    "OrnitheMC"
+  ],
+  "contact": {
+    "homepage": "https://ornithemc.net/",
+    "issues": "https://github.com/OrnitheMC/ornithe-standard-libraries/issues",
+    "sources": "https://github.com/OrnitheMC/ornithe-standard-libraries"
+  },
+  "license": "Apache-2.0"
+}

--- a/libraries/blockentities/blockentities-mc18w32a-mc1.14/src/main/resources/osl.blockentities.mixins.json
+++ b/libraries/blockentities/blockentities-mc18w32a-mc1.14/src/main/resources/osl.blockentities.mixins.json
@@ -1,0 +1,16 @@
+{
+	"required": true,
+	"minVersion": "0.8",
+	"package": "net.ornithemc.osl.blockentities.impl.mixin",
+	"compatibilityLevel": "JAVA_8",
+	"mixins": [
+		"common.BlockEntityTypeMixin"
+	],
+	"client": [
+	],
+	"server": [
+	],
+	"injectors": {
+		"defaultRequire": 1
+	}
+}

--- a/libraries/blockentities/blockentities-mca1.0.1_01-mc1.10.2/build.gradle
+++ b/libraries/blockentities/blockentities-mca1.0.1_01-mc1.10.2/build.gradle
@@ -1,0 +1,1 @@
+setUpModule(project)

--- a/libraries/blockentities/blockentities-mca1.0.1_01-mc1.10.2/gradle.properties
+++ b/libraries/blockentities/blockentities-mca1.0.1_01-mc1.10.2/gradle.properties
@@ -1,0 +1,4 @@
+min_mc_version = a1.0.1_01
+max_mc_version = 1.10.2
+
+minecraft_version = 1.10.2

--- a/libraries/blockentities/blockentities-mca1.0.1_01-mc1.10.2/src/main/java/net/ornithemc/osl/blockentities/api/BlockEntityEvents.java
+++ b/libraries/blockentities/blockentities-mca1.0.1_01-mc1.10.2/src/main/java/net/ornithemc/osl/blockentities/api/BlockEntityEvents.java
@@ -1,0 +1,34 @@
+package net.ornithemc.osl.blockentities.api;
+
+import net.ornithemc.osl.core.api.events.Event;
+
+/**
+ * Events related to the block entities lifecycle.
+ */
+public final class BlockEntityEvents {
+
+	/**
+	 * This event is invoked upon game start-up, after Vanilla block entity registration is finished.
+	 * 
+	 * <p>
+	 * Custom block entity type registration should be done in a listener of this event.
+	 * Helper methods for registering block entity types can be found in the {@linkplain
+	 * BlockEntityTypeRegistry} class.
+	 * 
+	 * <p>
+	 * Listeners to this event should be registered in your mod's entrypoint,
+	 * and can be done as follows:
+	 * 
+	 * <pre>
+	 * {@code
+	 * BlockEntityEvents.REGISTER_BLOCK_ENTITY_TYPES.register(() -> {
+	 * 	BlockEntityTypeRegistry.register(NamespacedIdentifiers.from("example", "cookie"), CookieBlockEntity.class);
+	 * });
+	 * }
+	 * </pre>
+	 * 
+	 * @see BlockEntityTypeRegistry
+	 */
+	public static final Event<Runnable> REGISTER_BLOCK_ENTITY_TYPES = Event.runnable();
+
+}

--- a/libraries/blockentities/blockentities-mca1.0.1_01-mc1.10.2/src/main/java/net/ornithemc/osl/blockentities/api/BlockEntityTypeRegistry.java
+++ b/libraries/blockentities/blockentities-mca1.0.1_01-mc1.10.2/src/main/java/net/ornithemc/osl/blockentities/api/BlockEntityTypeRegistry.java
@@ -1,0 +1,94 @@
+package net.ornithemc.osl.blockentities.api;
+
+import java.util.Set;
+
+import net.minecraft.block.entity.BlockEntity;
+
+import net.ornithemc.osl.blockentities.impl.BlockEntityTypeRegistryImpl;
+import net.ornithemc.osl.core.api.util.NamespacedIdentifier;
+import net.ornithemc.osl.registries.api.registry.Registry;
+import net.ornithemc.osl.registries.api.registry.ResourceKey;
+
+/**
+ * Public access to the Block Entity Types registry.
+ */
+public final class BlockEntityTypeRegistry {
+
+	public static final Registry<Class<? extends BlockEntity>> REGISTRY = BlockEntityTypeRegistryImpl.REGISTRY;
+
+	/**
+	 * @return the numerical ID assigned to the given block entity type.
+	 */
+	public static int getId(Class<? extends BlockEntity> type) {
+		return BlockEntityTypeRegistryImpl.getId(type);
+	}
+
+	/**
+	 * @return the namespaced ID assigned to the given block entity type.
+	 */
+	public static NamespacedIdentifier getIdentifier(Class<? extends BlockEntity> type) {
+		return BlockEntityTypeRegistryImpl.getIdentifier(type);
+	}
+
+	/**
+	 * @return the resource key assigned to the given block entity type.
+	 */
+	public static ResourceKey<Class<? extends BlockEntity>> getKey(Class<? extends BlockEntity> type) {
+		return BlockEntityTypeRegistryImpl.getKey(type);
+	}
+
+	/**
+	 * @return the block entity type mapped to the given numerical ID.
+	 */
+	public static Class<? extends BlockEntity> getBlockEntityType(int id) {
+		return BlockEntityTypeRegistryImpl.getBlockEntityType(id);
+	}
+
+	/**
+	 * @return the block entity type mapped to the given namespaced ID.
+	 */
+	public static Class<? extends BlockEntity> getBlockEntityType(NamespacedIdentifier identifier) {
+		return BlockEntityTypeRegistryImpl.getBlockEntityType(identifier);
+	}
+
+	/**
+	 * @return the block entity type mapped to the given resource key.
+	 */
+	public static Class<? extends BlockEntity> getBlockEntityType(ResourceKey<Class<? extends BlockEntity>> key) {
+		return BlockEntityTypeRegistryImpl.getBlockEntityType(key);
+	}
+
+	/**
+	 * @return a set containing all namespaced IDs in the registry.
+	 */
+	public static Set<NamespacedIdentifier> identifierSet() {
+		return BlockEntityTypeRegistryImpl.identifierSet();
+	}
+
+	/**
+	 * @return a set containing all resource keys in the registry.
+	 */
+	public static Set<ResourceKey<Class<? extends BlockEntity>>> keySet() {
+		return BlockEntityTypeRegistryImpl.keySet();
+	}
+
+	/**
+	 * @param <T>        the block entity type.
+	 * @param identifier the namespaced ID of the block entity type.
+	 * @param type       the block entity type to register.
+	 * @return the registered block entity type.
+	 */
+	public static <T extends BlockEntity> Class<T> register(NamespacedIdentifier identifier, Class<T> type) {
+		return BlockEntityTypeRegistryImpl.register(identifier, type);
+	}
+
+	/**
+	 * @param <T>   the block entity type.
+	 * @param key   the resource key of the block entity type.
+	 * @param type  the block entity type to register.
+	 * @return the registered block entity type.
+	 */
+	public static <T extends BlockEntity> Class<T> register(ResourceKey<Class<? extends BlockEntity>> key, Class<T> type) {
+		return BlockEntityTypeRegistryImpl.register(key, type);
+	}
+}

--- a/libraries/blockentities/blockentities-mca1.0.1_01-mc1.10.2/src/main/java/net/ornithemc/osl/blockentities/impl/BlockEntityTypeRegistryImpl.java
+++ b/libraries/blockentities/blockentities-mca1.0.1_01-mc1.10.2/src/main/java/net/ornithemc/osl/blockentities/impl/BlockEntityTypeRegistryImpl.java
@@ -1,0 +1,80 @@
+package net.ornithemc.osl.blockentities.impl;
+
+import java.util.Set;
+
+import net.minecraft.block.entity.BlockEntity;
+
+import net.ornithemc.osl.blockentities.api.BlockEntityEvents;
+import net.ornithemc.osl.core.api.util.NamespacedIdentifier;
+import net.ornithemc.osl.registries.api.registry.Registry;
+import net.ornithemc.osl.registries.api.registry.RegistryKeys;
+import net.ornithemc.osl.registries.api.registry.ResourceKey;
+import net.ornithemc.osl.registries.api.registry.SyncedRegistries;
+import net.ornithemc.osl.registries.impl.registry.RegistriesImpl;
+
+public final class BlockEntityTypeRegistryImpl {
+
+	public static final WrappedBlockEntityTypeRegistry REGISTRY = RegistriesImpl.register(RegistryKeys.BLOCK_ENTITY_TYPE, new WrappedBlockEntityTypeRegistry(RegistryKeys.BLOCK_ENTITY_TYPE.identifier()), () -> BlockEntity.ID_TO_TYPE.getClass());
+
+	private static boolean locked = true;
+
+	public static int getId(Class<? extends BlockEntity> type) {
+		return REGISTRY.getId(type);
+	}
+
+	public static NamespacedIdentifier getIdentifier(Class<? extends BlockEntity> type) {
+		return REGISTRY.getIdentifier(type);
+	}
+
+	public static ResourceKey<Class<? extends BlockEntity>> getKey(Class<? extends BlockEntity> type) {
+		return REGISTRY.getKey(type);
+	}
+
+	public static Class<? extends BlockEntity> getBlockEntityType(int id) {
+		return REGISTRY.get(id);
+	}
+
+	public static Class<? extends BlockEntity> getBlockEntityType(NamespacedIdentifier identifier) {
+		return REGISTRY.get(identifier);
+	}
+
+	public static Class<? extends BlockEntity> getBlockEntityType(ResourceKey<Class<? extends BlockEntity>> key) {
+		return REGISTRY.get(key);
+	}
+
+	public static Set<NamespacedIdentifier> identifierSet() {
+		return REGISTRY.identifierSet();
+	}
+
+	public static Set<ResourceKey<Class<? extends BlockEntity>>> keySet() {
+		return REGISTRY.keySet();
+	}
+
+	public static <T extends BlockEntity> Class<T> register(NamespacedIdentifier identifier, Class<T> type) {
+		if (locked) {
+			throw new IllegalStateException("register called too early: registry locked!");
+		} else {
+			return Registry.register(REGISTRY, identifier, type);
+		}
+	}
+
+	public static <T extends BlockEntity> Class<T> register(ResourceKey<Class<? extends BlockEntity>> key, Class<T> type) {
+		if (locked) {
+			throw new IllegalStateException("register called too early: registry locked!");
+		} else {
+			return Registry.register(REGISTRY, key, type);
+		}
+	}
+
+	public static void init() {
+		SyncedRegistries.register(RegistryKeys.BLOCK_ENTITY_TYPE);
+	}
+
+	public static void unlock() {
+		locked = false;
+	}
+
+	public static void registerBlockEntityTypes() {
+		BlockEntityEvents.REGISTER_BLOCK_ENTITY_TYPES.invoker().run();
+	}
+}

--- a/libraries/blockentities/blockentities-mca1.0.1_01-mc1.10.2/src/main/java/net/ornithemc/osl/blockentities/impl/VanillaBlockEntityTypes.java
+++ b/libraries/blockentities/blockentities-mca1.0.1_01-mc1.10.2/src/main/java/net/ornithemc/osl/blockentities/impl/VanillaBlockEntityTypes.java
@@ -1,0 +1,35 @@
+package net.ornithemc.osl.blockentities.impl;
+
+import com.google.common.collect.BiMap;
+import com.google.common.collect.HashBiMap;
+
+final class VanillaBlockEntityTypes {
+
+	static final BiMap<String, String> IDENTIFIERS = HashBiMap.create();
+
+	static {
+		IDENTIFIERS.put("Furnace", "furnace");
+		IDENTIFIERS.put("Chest", "chest");
+		IDENTIFIERS.put("EnderChest", "ender_chest");
+		IDENTIFIERS.put("RecordPlayer", "jukebox");
+		IDENTIFIERS.put("Trap", "dispenser");
+		IDENTIFIERS.put("Dropper", "dropper");
+		IDENTIFIERS.put("Sign", "sign");
+		IDENTIFIERS.put("MobSpawner", "mob_spawner");
+		IDENTIFIERS.put("Music", "noteblock");
+		IDENTIFIERS.put("Piston", "piston");
+		IDENTIFIERS.put("Cauldron", "brewing_stand");
+		IDENTIFIERS.put("EnchantTable", "enchanting_table");
+		IDENTIFIERS.put("Airportal", "end_portal");
+		IDENTIFIERS.put("Control", "command_block");
+		IDENTIFIERS.put("Beacon", "beacon");
+		IDENTIFIERS.put("Skull", "skull");
+		IDENTIFIERS.put("DLDetector", "daylight_detector");
+		IDENTIFIERS.put("Hopper", "hopper");
+		IDENTIFIERS.put("Comparator", "comparator");
+		IDENTIFIERS.put("FlowerPot", "flower_pot");
+		IDENTIFIERS.put("Banner", "banner");
+		IDENTIFIERS.put("Structure", "structure_block");
+		IDENTIFIERS.put("EndGateway", "end_gateway");
+	}
+}

--- a/libraries/blockentities/blockentities-mca1.0.1_01-mc1.10.2/src/main/java/net/ornithemc/osl/blockentities/impl/WrappedBlockEntityTypeRegistry.java
+++ b/libraries/blockentities/blockentities-mca1.0.1_01-mc1.10.2/src/main/java/net/ornithemc/osl/blockentities/impl/WrappedBlockEntityTypeRegistry.java
@@ -1,0 +1,118 @@
+package net.ornithemc.osl.blockentities.impl;
+
+import java.util.Set;
+
+import com.google.common.collect.BiMap;
+import com.google.common.collect.HashBiMap;
+
+import net.minecraft.block.entity.BlockEntity;
+
+import net.ornithemc.osl.core.api.util.NamespacedIdentifier;
+import net.ornithemc.osl.core.api.util.NamespacedIdentifiers;
+import net.ornithemc.osl.registries.api.registry.ResourceKey;
+import net.ornithemc.osl.registries.api.registry.ResourceKeys;
+import net.ornithemc.osl.registries.impl.registry.SimpleRegistry;
+
+public class WrappedBlockEntityTypeRegistry extends SimpleRegistry<Class<? extends BlockEntity>> {
+
+	private final BiMap<NamespacedIdentifier, String> legacyIds = HashBiMap.create();
+
+	private boolean skipBlockEntityRegister;
+
+	WrappedBlockEntityTypeRegistry(NamespacedIdentifier identifier) {
+		super(identifier);
+	}
+
+	public void register(String legacyId, Class<? extends BlockEntity> type) {
+		NamespacedIdentifier identifier = this.constructIdentifier(legacyId);
+		ResourceKey<Class<? extends BlockEntity>> key = ResourceKeys.from(this.identifier(), identifier);
+
+		this.skipBlockEntityRegister = true;
+		this.register(key, type);
+		this.skipBlockEntityRegister = false;
+	}
+
+	@Override
+	public <V extends Class<? extends BlockEntity>> V register(int id, ResourceKey<Class<? extends BlockEntity>> key, V type) {
+		type = super.register(id, key, type);
+
+		if (!this.skipBlockEntityRegister) {
+			NamespacedIdentifier identifier = key.identifier();
+			String legacyId = this.constructLegacyId(identifier);
+
+			if (BlockEntity.ID_TO_TYPE.containsKey(legacyId)) {
+				throw new IllegalStateException("Duplicate legacy BlockEntity type ID " + legacyId);
+			}
+
+			BlockEntity.ID_TO_TYPE.put(legacyId, type);
+			BlockEntity.TYPE_TO_ID.put(type, legacyId);
+		}
+
+		return type;
+	}
+
+	private String constructLegacyId(NamespacedIdentifier identifier) {
+		return this.legacyIds.computeIfAbsent(identifier, key -> {
+			if (identifier.namespace().equals(NamespacedIdentifiers.DEFAULT_NAMESPACE)) {
+				String legacyId = VanillaBlockEntityTypes.IDENTIFIERS.inverse().get(identifier.identifier());
+
+				if (legacyId != null) {
+					return legacyId;
+				}
+			}
+
+			return identifier.toString();
+		});
+	}
+
+	private NamespacedIdentifier constructIdentifier(String legacyId) {
+		return this.legacyIds.inverse().computeIfAbsent(legacyId, key -> {
+			String identifier = VanillaBlockEntityTypes.IDENTIFIERS.get(legacyId);
+
+			if (identifier != null) {
+				return NamespacedIdentifiers.from(identifier);
+			}
+
+			StringBuilder sb = new StringBuilder();
+
+			// convert PascalCase to snake_case
+			for (int i = 0; i < legacyId.length(); i++) {
+				char chr = legacyId.charAt(i);
+
+				if (Character.isUpperCase(chr)) {
+					chr = Character.toLowerCase(chr);
+
+					if (i != 0) {
+						sb.append('_');
+					}
+				}
+
+				sb.append(chr);
+			}
+
+			return NamespacedIdentifiers.from(sb.toString());
+		});
+	}
+
+	public Class<? extends BlockEntity> get(String legacyId) {
+		NamespacedIdentifier identifier = this.legacyIds.inverse().get(legacyId);
+		return identifier == null ? null : this.get(identifier);
+	}
+
+	public String getLegacyId(Class<? extends BlockEntity> type) {
+		NamespacedIdentifier identifier = this.getIdentifier(type);
+		return identifier == null ? null : this.legacyIds.get(identifier);
+	}
+
+	public Set<String> legacyIdSet() {
+		return this.legacyIds.values();
+	}
+
+	@Override
+	public void clear() {
+		super.clear();
+
+		BlockEntity.ID_TO_TYPE.clear();
+		BlockEntity.TYPE_TO_ID.clear();
+	}
+}

--- a/libraries/blockentities/blockentities-mca1.0.1_01-mc1.10.2/src/main/java/net/ornithemc/osl/blockentities/impl/mixin/common/BlockEntityMixin.java
+++ b/libraries/blockentities/blockentities-mca1.0.1_01-mc1.10.2/src/main/java/net/ornithemc/osl/blockentities/impl/mixin/common/BlockEntityMixin.java
@@ -1,0 +1,44 @@
+package net.ornithemc.osl.blockentities.impl.mixin.common;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import net.minecraft.block.entity.BlockEntity;
+
+import net.ornithemc.osl.blockentities.impl.BlockEntityTypeRegistryImpl;
+
+@Mixin(BlockEntity.class)
+public class BlockEntityMixin {
+
+	@Inject(
+		method = "register",
+		at = @At(
+			value = "TAIL"
+		)
+	)
+	private static void osl$blockentities$register(Class<? extends BlockEntity> type, String legacyId, CallbackInfo ci) {
+		BlockEntityTypeRegistryImpl.REGISTRY.register(legacyId, type);
+	}
+
+	@Inject(
+		method = "<clinit>",
+		at = @At(
+			value = "HEAD"
+		)
+	)
+	private static void osl$blockentities$unlockBlockEntityTypeRegistry(CallbackInfo ci) {
+		BlockEntityTypeRegistryImpl.unlock();
+	}
+
+	@Inject(
+		method = "<clinit>",
+		at = @At(
+			value = "TAIL"
+		)
+	)
+	private static void osl$blockentities$registerBlockEntityTypes(CallbackInfo ci) {
+		BlockEntityTypeRegistryImpl.registerBlockEntityTypes();
+	}
+}

--- a/libraries/blockentities/blockentities-mca1.0.1_01-mc1.10.2/src/main/resources/fabric.mod.json
+++ b/libraries/blockentities/blockentities-mca1.0.1_01-mc1.10.2/src/main/resources/fabric.mod.json
@@ -1,0 +1,38 @@
+{
+  "schemaVersion": 1,
+  "id": "osl-blockentities",
+  "version": "0.1.0+mca1.0.1_01-mc1.10.2",
+  "environment": "*",
+  "entrypoints": {
+    "init": [
+      "net.ornithemc.osl.blockentities.impl.BlockEntityTypeRegistryImpl::init"
+    ]
+  },
+  "mixins": [
+    "osl.blockentities.mixins.json"
+  ],
+  "accessWidener": "osl.blockentities.classtweaker",
+  "depends": {
+    "fabricloader": "\u003e\u003d0.18.0",
+    "minecraft": "\u003e\u003d1.0.0-alpha.0.1.1 \u003c\u003d1.10.2",
+    "osl-core": "\u003e\u003d0.9.0",
+    "osl-entrypoints": "\u003e\u003d0.5.0",
+    "osl-lifecycle-events": "\u003e\u003d0.6.0",
+    "osl-executors": "\u003e\u003d0.1.0",
+    "osl-text-components": "\u003e\u003d0.1.0-",
+    "osl-networking": "\u003e\u003d0.10.0",
+    "osl-networking-impl": "\u003e\u003d0.2.0",
+    "osl-registries": "\u003e\u003d0.1.0"
+  },
+  "name": "OSL Block Entities",
+  "description": "Block Entities API and events.",
+  "authors": [
+    "OrnitheMC"
+  ],
+  "contact": {
+    "homepage": "https://ornithemc.net/",
+    "issues": "https://github.com/OrnitheMC/ornithe-standard-libraries/issues",
+    "sources": "https://github.com/OrnitheMC/ornithe-standard-libraries"
+  },
+  "license": "Apache-2.0"
+}

--- a/libraries/blockentities/blockentities-mca1.0.1_01-mc1.10.2/src/main/resources/osl.blockentities.classtweaker
+++ b/libraries/blockentities/blockentities-mca1.0.1_01-mc1.10.2/src/main/resources/osl.blockentities.classtweaker
@@ -1,0 +1,6 @@
+classTweaker	v1	named
+
+accessible	field	net/minecraft/block/entity/BlockEntity	ID_TO_TYPE	Ljava/util/Map;
+accessible	field	net/minecraft/block/entity/BlockEntity	TYPE_TO_ID	Ljava/util/Map;
+
+accessible	method	net/minecraft/block/entity/BlockEntity	register	(Ljava/lang/Class;Ljava/lang/String;)V

--- a/libraries/blockentities/blockentities-mca1.0.1_01-mc1.10.2/src/main/resources/osl.blockentities.mixins.json
+++ b/libraries/blockentities/blockentities-mca1.0.1_01-mc1.10.2/src/main/resources/osl.blockentities.mixins.json
@@ -1,0 +1,16 @@
+{
+	"required": true,
+	"minVersion": "0.8",
+	"package": "net.ornithemc.osl.blockentities.impl.mixin",
+	"compatibilityLevel": "JAVA_8",
+	"mixins": [
+		"common.BlockEntityMixin"
+	],
+	"client": [
+	],
+	"server": [
+	],
+	"injectors": {
+		"defaultRequire": 1
+	}
+}

--- a/libraries/blockentities/build.gradle
+++ b/libraries/blockentities/build.gradle
@@ -1,0 +1,1 @@
+setUpLibrary(project)

--- a/libraries/blockentities/gradle.properties
+++ b/libraries/blockentities/gradle.properties
@@ -1,0 +1,7 @@
+library_id = blockentities
+library_name = Block Entities
+library_description = Block Entities API and events.
+library_version = 0.1.0
+
+entrypoint_init = net.ornithemc.osl.blockentities.impl.BlockEntityTypeRegistryImpl::init
+osl_dependencies = core:0.9.0,entrypoints:0.5.0,registries:0.1.0

--- a/libraries/registries/registries-mc12w18a-mc1.6.4/src/main/java/net/ornithemc/osl/registries/api/registry/RegistryKeys.java
+++ b/libraries/registries/registries-mc12w18a-mc1.6.4/src/main/java/net/ornithemc/osl/registries/api/registry/RegistryKeys.java
@@ -1,6 +1,7 @@
 package net.ornithemc.osl.registries.api.registry;
 
 import net.minecraft.block.Block;
+import net.minecraft.block.entity.BlockEntity;
 import net.minecraft.item.Item;
 
 import net.ornithemc.osl.core.api.util.NamespacedIdentifier;
@@ -15,6 +16,7 @@ public final class RegistryKeys {
 
 	public static final ResourceKey<Registry<Block>> BLOCK = from("block");
 	public static final ResourceKey<Registry<Item>> ITEM = from("item");
+	public static final ResourceKey<Registry<Class<? extends BlockEntity>>> BLOCK_ENTITY_TYPE = from("block_entity_type");
 
 	/**
 	 * Constructs a registry key with the default namespace and the given identifier.

--- a/libraries/registries/registries-mc13w36a-mc14w26c/src/main/java/net/ornithemc/osl/registries/api/registry/RegistryKeys.java
+++ b/libraries/registries/registries-mc13w36a-mc14w26c/src/main/java/net/ornithemc/osl/registries/api/registry/RegistryKeys.java
@@ -1,6 +1,7 @@
 package net.ornithemc.osl.registries.api.registry;
 
 import net.minecraft.block.Block;
+import net.minecraft.block.entity.BlockEntity;
 import net.minecraft.item.Item;
 
 import net.ornithemc.osl.core.api.util.NamespacedIdentifier;
@@ -15,6 +16,7 @@ public final class RegistryKeys {
 
 	public static final ResourceKey<Registry<Block>> BLOCK = from("block");
 	public static final ResourceKey<Registry<Item>> ITEM = from("item");
+	public static final ResourceKey<Registry<Class<? extends BlockEntity>>> BLOCK_ENTITY_TYPE = from("block_entity_type");
 
 	/**
 	 * Constructs a registry key with the default namespace and the given identifier.

--- a/libraries/registries/registries-mc14w27a-mc17w46a/src/main/java/net/ornithemc/osl/registries/api/registry/RegistryKeys.java
+++ b/libraries/registries/registries-mc14w27a-mc17w46a/src/main/java/net/ornithemc/osl/registries/api/registry/RegistryKeys.java
@@ -1,6 +1,7 @@
 package net.ornithemc.osl.registries.api.registry;
 
 import net.minecraft.block.Block;
+import net.minecraft.block.entity.BlockEntity;
 import net.minecraft.item.Item;
 
 import net.ornithemc.osl.core.api.util.NamespacedIdentifier;
@@ -15,6 +16,7 @@ public final class RegistryKeys {
 
 	public static final ResourceKey<Registry<Block>> BLOCK = from("block");
 	public static final ResourceKey<Registry<Item>> ITEM = from("item");
+	public static final ResourceKey<Registry<Class<? extends BlockEntity>>> BLOCK_ENTITY_TYPE = from("block_entity_type");
 
 	/**
 	 * Constructs a registry key with the default namespace and the given identifier.

--- a/libraries/registries/registries-mc17w47a-mc18w31a/src/main/java/net/ornithemc/osl/registries/api/registry/RegistryKeys.java
+++ b/libraries/registries/registries-mc17w47a-mc18w31a/src/main/java/net/ornithemc/osl/registries/api/registry/RegistryKeys.java
@@ -1,6 +1,7 @@
 package net.ornithemc.osl.registries.api.registry;
 
 import net.minecraft.block.Block;
+import net.minecraft.block.entity.BlockEntityType;
 import net.minecraft.item.Item;
 
 import net.ornithemc.osl.core.api.util.NamespacedIdentifier;
@@ -15,6 +16,7 @@ public final class RegistryKeys {
 
 	public static final ResourceKey<Registry<Block>> BLOCK = from("block");
 	public static final ResourceKey<Registry<Item>> ITEM = from("item");
+	public static final ResourceKey<Registry<BlockEntityType<?>>> BLOCK_ENTITY_TYPE = from("block_entity_type");
 
 	/**
 	 * Constructs a registry key with the default namespace and the given identifier.

--- a/libraries/registries/registries-mc18w32a-mc1.13.2/src/main/java/net/ornithemc/osl/registries/api/registry/RegistryKeys.java
+++ b/libraries/registries/registries-mc18w32a-mc1.13.2/src/main/java/net/ornithemc/osl/registries/api/registry/RegistryKeys.java
@@ -1,6 +1,7 @@
 package net.ornithemc.osl.registries.api.registry;
 
 import net.minecraft.block.Block;
+import net.minecraft.block.entity.BlockEntityType;
 import net.minecraft.item.Item;
 
 import net.ornithemc.osl.core.api.util.NamespacedIdentifier;
@@ -15,6 +16,7 @@ public final class RegistryKeys {
 
 	public static final ResourceKey<Registry<Block>> BLOCK = from("block");
 	public static final ResourceKey<Registry<Item>> ITEM = from("item");
+	public static final ResourceKey<Registry<BlockEntityType<?>>> BLOCK_ENTITY_TYPE = from("block_entity_type");
 
 	/**
 	 * Constructs a registry key with the default namespace and the given identifier.

--- a/libraries/registries/registries-mc18w43a-mc19w03c/src/main/java/net/ornithemc/osl/registries/api/registry/RegistryKeys.java
+++ b/libraries/registries/registries-mc18w43a-mc19w03c/src/main/java/net/ornithemc/osl/registries/api/registry/RegistryKeys.java
@@ -1,6 +1,7 @@
 package net.ornithemc.osl.registries.api.registry;
 
 import net.minecraft.block.Block;
+import net.minecraft.block.entity.BlockEntityType;
 import net.minecraft.item.Item;
 
 import net.ornithemc.osl.core.api.util.NamespacedIdentifier;
@@ -15,6 +16,7 @@ public final class RegistryKeys {
 
 	public static final ResourceKey<Registry<Block>> BLOCK = from("block");
 	public static final ResourceKey<Registry<Item>> ITEM = from("item");
+	public static final ResourceKey<Registry<BlockEntityType<?>>> BLOCK_ENTITY_TYPE = from("block_entity_type");
 
 	/**
 	 * Constructs a registry key with the default namespace and the given identifier.

--- a/libraries/registries/registries-mc19w04a-mc1.14.4/src/main/java/net/ornithemc/osl/registries/api/registry/RegistryKeys.java
+++ b/libraries/registries/registries-mc19w04a-mc1.14.4/src/main/java/net/ornithemc/osl/registries/api/registry/RegistryKeys.java
@@ -1,6 +1,7 @@
 package net.ornithemc.osl.registries.api.registry;
 
 import net.minecraft.block.Block;
+import net.minecraft.block.entity.BlockEntityType;
 import net.minecraft.item.Item;
 
 import net.ornithemc.osl.core.api.util.NamespacedIdentifier;
@@ -15,6 +16,7 @@ public final class RegistryKeys {
 
 	public static final ResourceKey<Registry<Block>> BLOCK = from("block");
 	public static final ResourceKey<Registry<Item>> ITEM = from("item");
+	public static final ResourceKey<Registry<BlockEntityType<?>>> BLOCK_ENTITY_TYPE = from("block_entity_type");
 
 	/**
 	 * Constructs a registry key with the default namespace and the given identifier.

--- a/libraries/registries/registries-mca1.0.1_01-mc12w17a/src/main/java/net/ornithemc/osl/registries/api/registry/RegistryKeys.java
+++ b/libraries/registries/registries-mca1.0.1_01-mc12w17a/src/main/java/net/ornithemc/osl/registries/api/registry/RegistryKeys.java
@@ -1,6 +1,7 @@
 package net.ornithemc.osl.registries.api.registry;
 
 import net.minecraft.block.Block;
+import net.minecraft.block.entity.BlockEntity;
 import net.minecraft.item.Item;
 
 import net.ornithemc.osl.core.api.util.NamespacedIdentifier;
@@ -15,6 +16,7 @@ public final class RegistryKeys {
 
 	public static final ResourceKey<Registry<Block>> BLOCK = from("block");
 	public static final ResourceKey<Registry<Item>> ITEM = from("item");
+	public static final ResourceKey<Registry<Class<? extends BlockEntity>>> BLOCK_ENTITY_TYPE = from("block_entity_type");
 
 	/**
 	 * Constructs a registry key with the default namespace and the given identifier.

--- a/settings.gradle
+++ b/settings.gradle
@@ -38,6 +38,9 @@ include ':libraries:blockentities:blockentities-mc1.13-pre5-mc18w31a'
 include ':libraries:blockentities:blockentities-mc18w32a-mc1.14'
 include ':libraries:blockentities:blockentities-mc1.14.1-pre1-mc1.14.4'
 
+include ':libraries:blockentities-rendering'
+include ':libraries:blockentities-rendering:blockentities-rendering-mca1.0.1_01-mc1.14.4'
+
 include ':libraries:branding'
 include ':libraries:branding:branding-mcin-20100206-2103-mca1.2.1_01'
 include ':libraries:branding:branding-mca1.2.2-mc14w29b'

--- a/settings.gradle
+++ b/settings.gradle
@@ -31,6 +31,13 @@ include ':libraries:blocks:blocks-mc17w47a-mc18w31a'
 include ':libraries:blocks:blocks-mc18w32a-mc1.13.2'
 include ':libraries:blocks:blocks-mc18w43a-mc1.14.4'
 
+include ':libraries:blockentities'
+include ':libraries:blockentities:blockentities-mca1.0.1_01-mc1.10.2'
+include ':libraries:blockentities:blockentities-mc16w32a-mc18w01a'
+include ':libraries:blockentities:blockentities-mc1.13-pre5-mc18w31a'
+include ':libraries:blockentities:blockentities-mc18w32a-mc1.14'
+include ':libraries:blockentities:blockentities-mc1.14.1-pre1-mc1.14.4'
+
 include ':libraries:branding'
 include ':libraries:branding:branding-mcin-20100206-2103-mca1.2.1_01'
 include ':libraries:branding:branding-mca1.2.2-mc14w29b'


### PR DESCRIPTION
Basic APIs for registering block entity types and block entity renderers.

## Registering Block Entity Types

```java
package com.example;

import net.ornithemc.osl.blockentities.api.BlockEntityEvents;
import net.ornithemc.osl.entrypoints.api.ModInitializer;

public class ExampleInitializer implements ModInitializer {

	@Override
	public void init() {
		BlockEntityEvents.REGISTER_BLOCK_ENTITY_TYPES.register(ExampleBlockEntityTypes::init);
	}
}
```

```java
package com.example;

import net.minecraft.block.entity.BlockEntityType;

import net.ornithemc.osl.blockentities.api.BlockEntityTypeRegistry;
import net.ornithemc.osl.blockentities.api.BlockEntityTypes;
import net.ornithemc.osl.core.util.NamespacedIdentifiers;

public final class ExampleBlockEntityTypes {

	public static final BlockEntityType<CookieBlockEntity> COOKIE = BlockEntityTypeRegistry.register(NamespacedIdentifiers.from("example", "cookie"), BlockEntityTypes.builder(CookieBlockEntity::new, ExampleBlocks.COOKIE));

	public static void init() {
	}
}
```

## Registering Block Entity Renderers

```java
package com.example;

import net.ornithemc.osl.blockentities.api.client.BlockEntityRenderingEvents;
import net.ornithemc.osl.entrypoints.api.client.ClientModInitializer;

public class ExampleInitializer implements ClientModInitializer {

	@Override
	public void initClient() {
		BlockEntityRenderingEvents.REGISTER_BLOCK_ENTITY_RENDERERS.register(registry -> {
			registry.register(CookieBlockEntity.class, CookieBlockRenderer::new);
		});
	}
}
```